### PR TITLE
Fix movie search API query parameter

### DIFF
--- a/src/app/service/moviedatabase.service.ts
+++ b/src/app/service/moviedatabase.service.ts
@@ -22,7 +22,7 @@ export class MoviedatabaseService {
   searchFilm(title: string, releaseYear: number): Promise<Result> {
     return lastValueFrom(
       this.http.get<Result>(
-        `https://api.themoviedb.org/3/search/movie?api_key=${this.apiKey}&query=${title}&year&=${releaseYear}`
+        `https://api.themoviedb.org/3/search/movie?api_key=${this.apiKey}&query=${title}&year=${releaseYear}`
       )
     );
   }


### PR DESCRIPTION
## Summary
- correct the year parameter in `MoviedatabaseService.searchFilm`

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find module '@angular/core')*

------
https://chatgpt.com/codex/tasks/task_e_684ad3190c5083279f57e75975d5020d