### PR TITLE
Improve movie calendar UI

### DIFF
--- a/src/app/bookmarked-films/bookmarked-films.component.html
+++ b/src/app/bookmarked-films/bookmarked-films.component.html
@@ -1,14 +1,19 @@
-<div class="container">
-  <div
-    class="header-container"
-    style="display: flex; align-items: center; justify-content: space-between"
-  >
-    <h1 class="title">All Movies</h1>
-    <div class="select-wrapper" style="position: relative">
+<div class="container mx-auto p-4">
+  <div class="flex flex-wrap items-center justify-between mb-4">
+    <div class="flex items-center space-x-2">
+      <button class="p-2" (click)="previousYear()">
+        <i class="fas fa-chevron-left"></i>
+      </button>
+      <span class="text-lg font-semibold">{{ selectedYear }}</span>
+      <button class="p-2" (click)="nextYear()">
+        <i class="fas fa-chevron-right"></i>
+      </button>
+    </div>
+    <div class="flex items-center space-x-2">
       <select
         [(ngModel)]="selectedValue"
         (change)="onFilterChange()"
-        class="custom-select"
+        class="border rounded p-1"
       >
         <option
           *ngFor="let value of filterValues"
@@ -20,55 +25,30 @@
       </select>
     </div>
   </div>
-  <div class="columns is-multiline">
-    <div class="column is-half" *ngFor="let movie of bookmarkedMovies">
-      <div class="box" style="padding-bottom: 20px">
-        <article class="media">
-          <div class="media-left">
-            <figure class="image is-96x96">
-              <img
-                [src]="
-                  'https://image.tmdb.org/t/p/original' + movie.poster_path
-                "
-                alt="{{ movie.title }}"
-                style="max-width: 90%; max-height: 125%"
-              />
-            </figure>
-          </div>
-          <div class="media-content">
-            <div class="content">
-              <p>
-                <a
-                  href="https://www.themoviedb.org/movie/{{ movie.id }}"
-                  target="_blank"
-                >
-                  {{ movie.title }}
-                </a>
-                <br />
-                {{ movie.release_date }}
-                <br />
-                <br />
-                <button class="button">Download Calendar</button>
-              </p>
-              <div class="bookmark-container">
-                <button
-                  class="transparent-button"
-                  (click)="toggleBookmark(movie)"
-                >
-                  <i
-                    class="fa-solid fa-bookmark"
-                    *ngIf="movie.isBookmarked"
-                  ></i>
-                  <i
-                    class="fa-regular fa-bookmark"
-                    *ngIf="!movie.isBookmarked"
-                  ></i>
-                </button>
-              </div>
-            </div>
-          </div>
-        </article>
-      </div>
+
+  <div class="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+    <div *ngFor="let movie of bookmarkedMovies" class="bg-white rounded shadow hover:shadow-lg transition p-4 relative">
+      <button
+        class="absolute top-2 right-2 text-yellow-500"
+        (click)="toggleBookmark(movie)"
+      >
+        <i class="fa-solid fa-bookmark" *ngIf="movie.isBookmarked"></i>
+        <i class="fa-regular fa-bookmark" *ngIf="!movie.isBookmarked"></i>
+      </button>
+      <img
+        [src]="'https://image.tmdb.org/t/p/original' + movie.poster_path"
+        alt="{{ movie.title }}"
+        loading="lazy"
+        class="w-full h-48 object-cover rounded mb-2"
+      />
+      <h2 class="text-lg font-semibold">{{ movie.title }}</h2>
+      <p class="text-sm text-gray-500">{{ movie.release_date }}</p>
+      <button
+        class="mt-2 px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 transition"
+        (click)="downloadICSCalendar(movie)"
+      >
+        <i class="fas fa-calendar-plus mr-1"></i> Download Calendar
+      </button>
     </div>
   </div>
 

--- a/src/app/calendar/calendar.component.html
+++ b/src/app/calendar/calendar.component.html
@@ -5,37 +5,26 @@
 <div *ngIf="!loading">
   <div class="container">
     <div class="calendar">
-      <div class="date-selector">
-        <div class="field is-grouped">
-          <div class="control">
-            <div class="select">
-              <select [(ngModel)]="selectedMonth" (change)="onDateChange()">
-                <option *ngFor="let month of months; let i = index" [value]="i">
-                  {{ month }}
-                </option>
-              </select>
-            </div>
-          </div>
-          <div class="control">
-            <div class="select">
-              <select [(ngModel)]="selectedView">
-                <option>Month</option>
-                <option>Week</option>
-              </select>
-              <!--
-            <select [(ngModel)]="selectedYear" (change)="onDateChange()">
-              <option *ngFor="let year of years" [value]="year">
-                {{ year }}
-              </option>
-            </select>
-            --></div>
-          </div>
-          <div class="month-title title">
-            <h1>
-              Releasedates for {{ months[selectedMonth] }} {{ selectedYear }}
-            </h1>
-          </div>
+      <div class="date-selector flex flex-wrap items-center justify-between mb-4">
+        <div class="flex items-center space-x-2">
+          <button class="p-2" (click)="previousYear()">
+            <i class="fas fa-chevron-left"></i>
+          </button>
+          <span class="text-lg font-semibold">{{ selectedYear }}</span>
+          <button class="p-2" (click)="nextYear()">
+            <i class="fas fa-chevron-right"></i>
+          </button>
         </div>
+        <div class="flex items-center space-x-2">
+          <select [(ngModel)]="selectedMonth" (change)="onDateChange()" class="border rounded p-1">
+            <option *ngFor="let month of months; let i = index" [value]="i">{{ month }}</option>
+          </select>
+          <select [(ngModel)]="selectedView" class="border rounded p-1">
+            <option>Month</option>
+            <option>Week</option>
+          </select>
+        </div>
+        <h1 class="text-xl font-bold ml-4">Releasedates for {{ months[selectedMonth] }} {{ selectedYear }}</h1>
       </div>
 
       <div class="week">
@@ -51,7 +40,7 @@
         <div class="week" *ngFor="let week of weeks">
           <ng-container *ngFor="let day of week; let i = index">
             <div
-              class="day square"
+              class="day square rounded-md shadow-sm hover:shadow-md transition"
               [ngClass]="{ 'weekend-day': i === 5 || i === 6 }"
               (click)="onDayClick(day)"
               (mouseenter)="onDayMouseEnter(day)"
@@ -64,16 +53,22 @@
 
                 <div *ngFor="let movie of getMoviesForDay(day); let i = index">
                   <div
-                    class="small-text"
+                    class="small-text flex items-center justify-between"
                     [ngClass]="{
                       'bookmarked-movie': movie.isBookmarked,
                       'film-background': !movie.isBookmarked
                     }"
                   >
-                    <strong style="color: white">{{
-                      movie.title | slice : 0 : 25
-                    }}</strong>
-                    <!-- ({{ movie.release_date | date : "yyyy" }}) -->
+                    <span class="truncate text-white">{{ movie.title | slice:0:25 }}</span>
+                    <div class="flex items-center space-x-1">
+                      <button class="text-yellow-400" (click)="toggleBookmark(movie); $event.stopPropagation();">
+                        <i class="fa-solid fa-bookmark" *ngIf="movie.isBookmarked"></i>
+                        <i class="fa-regular fa-bookmark" *ngIf="!movie.isBookmarked"></i>
+                      </button>
+                      <button class="text-blue-200" (click)="downloadICSCalendar(movie); $event.stopPropagation();">
+                        <i class="fas fa-download"></i>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div *ngIf="getMovieCountForDay(day) >= 1" class="movie-count">
@@ -111,7 +106,7 @@
         </div>
         <div
           *ngFor="let day of weeks[0]; let i = index"
-          class="day square week-square"
+          class="day square week-square rounded-md shadow-sm hover:shadow-md transition"
           [ngClass]="{ 'weekend-day': i === 5 || i === 6 }"
           (click)="onDayClick(day)"
         >
@@ -120,15 +115,22 @@
 
             <div *ngFor="let movie of getMoviesForWeek(day); let i = index">
               <div
-                class="small-text"
+                class="small-text flex items-center justify-between"
                 [ngClass]="{
                   'bookmarked-movie': movie.isBookmarked,
                   'film-background': !movie.isBookmarked
                 }"
               >
-                <strong style="color: white">
-                  {{ movie.title | slice : 0 : 25 }}
-                </strong>
+                <span class="truncate text-white">{{ movie.title | slice:0:25 }}</span>
+                <div class="flex items-center space-x-1">
+                  <button class="text-yellow-400" (click)="toggleBookmark(movie); $event.stopPropagation();">
+                    <i class="fa-solid fa-bookmark" *ngIf="movie.isBookmarked"></i>
+                    <i class="fa-regular fa-bookmark" *ngIf="!movie.isBookmarked"></i>
+                  </button>
+                  <button class="text-blue-200" (click)="downloadICSCalendar(movie); $event.stopPropagation();">
+                    <i class="fas fa-download"></i>
+                  </button>
+                </div>
               </div>
             </div>
           </ng-container>

--- a/src/index.html
+++ b/src/index.html
@@ -12,6 +12,8 @@
       integrity="sha384-KyZXEAg3QhqLMpG8r+2Ku3pxz5WviE+7f5z5l5u0U3/5AXSB1wFprFhOHnS9t5Ij9"
       crossorigin="anonymous"
     />
+    <!-- Tailwind CSS via CDN for quick styling -->
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
     <app-root></app-root>


### PR DESCRIPTION
## Summary
- add Tailwind CDN
- refine bookmarked movies list UI
- filter bookmarked movies by year
- enhance calendar view with year navigation and actions
- allow bookmarking and calendar download directly from month and week views

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c646488a483278a532821e07b28ef