### PR TITLE
Improve movie details layout

### DIFF
--- a/src/app/calendar-detail/calendar-detail.component.css
+++ b/src/app/calendar-detail/calendar-detail.component.css
@@ -1,36 +1,15 @@
-.custom-image {
-  width: 80px; /* Adjust to your preferred width */
-  height: 80px; /* Adjust to your preferred height */
-}
-
-.text-center {
-  text-align: center;
-}
-
-.media-content {
-  position: relative; /* Position relative for bookmark-container */
-}
-
-.bookmark-container {
-  position: absolute;
-  top: 0;
-  right: 0;
-  margin-top: 5px; /* Adjust top margin for spacing */
-}
-
 .transparent-button {
   background-color: transparent;
   border: none; /* Optionally, remove the button border */
   padding: 0; /* Optionally, remove padding to make it as small as possible */
 }
 
-.custom {
-  padding-right: 33%;
+.movie-card {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
-.control {
-  display: flex;
-  justify-content: space-between; /* Positions the buttons at opposite ends */
-  align-items: center; /* Centers them vertically if there's extra height */
-  margin-bottom: 25px;
+.custom-select {
+  padding: 0.25rem;
 }

--- a/src/app/calendar-detail/calendar-detail.component.html
+++ b/src/app/calendar-detail/calendar-detail.component.html
@@ -1,14 +1,21 @@
 <div class="container">
-  <h1 class="title is-size-3">{{ date }}</h1>
-  <h1 class="title is-size-4">Bookmarked Movies</h1>
-  <div class="control">
-    <button (click)="onDateChangePrevious()" class="button left">
-      <i class="fas fa-arrow-left"></i>
-    </button>
-    <button (click)="onDateChangeNext()" class="button right">
-      <i class="fas fa-arrow-right"></i>
-    </button>
+  <div class="level my-4">
+    <div class="level-left">
+      <button (click)="onDateChangePrevious()" class="button">
+        <i class="fas fa-arrow-left"></i>
+      </button>
+    </div>
+    <div class="level-item">
+      <h1 class="title is-size-3">{{ date }}</h1>
+    </div>
+    <div class="level-right">
+      <button (click)="onDateChangeNext()" class="button">
+        <i class="fas fa-arrow-right"></i>
+      </button>
+    </div>
   </div>
+
+  <h2 class="title is-size-4">Bookmarked Movies</h2>
 
   <div *ngIf="isLoadingBookmarked" class="has-text-centered">
     <button class="button is-large is-loading is-white">
@@ -17,74 +24,56 @@
   </div>
 
   <div class="columns is-multiline">
-    <div class="column is-half" *ngFor="let movie of bookmarkedMovies">
-      <div class="box">
-        <article class="media">
-          <div class="media-left">
-            <figure class="image is-96x96">
-              <img
-                [src]="
-                  'https://image.tmdb.org/t/p/original' + movie.poster_path
-                "
-                alt="{{ movie.title }}"
-              />
-            </figure>
+    <div class="column is-one-third" *ngFor="let movie of bookmarkedMovies">
+      <div class="card movie-card">
+        <div class="card-image">
+          <figure class="image is-2by3">
+            <img
+              [src]="'https://image.tmdb.org/t/p/original' + movie.poster_path"
+              alt="{{ movie.title }}"
+            />
+          </figure>
+        </div>
+        <div class="card-content">
+          <p class="title is-5">
+            <a href="https://www.themoviedb.org/movie/{{ movie.id }}" target="_blank"
+              >{{ movie.title }}</a
+            >
+          </p>
+          <p class="subtitle is-6">
+            <span *ngIf="!editing[movie.id]" (click)="enableEditing(movie)">
+              {{ movie.release_date }} |
+              <strong>{{ calculateReleasedYearsAgo(movie) }} year(s) ago</strong>
+            </span>
+            <input
+              *ngIf="editing[movie.id]"
+              type="text"
+              [value]="movie.release_date"
+              (keyup.enter)="updateReleaseDate($event, movie)"
+              (blur)="disableEditing(movie)"
+            />
+          </p>
+          <div class="buttons">
+            <button (click)="downloadICSCalendar(movie)" class="button is-small">
+              Download Calendar
+            </button>
+            <button
+              class="transparent-button"
+              (click)="toggleBookmark(movie)"
+            >
+              <i class="fa-solid fa-bookmark" *ngIf="movie.isBookmarked"></i>
+              <i class="fa-regular fa-bookmark" *ngIf="!movie.isBookmarked"></i>
+            </button>
           </div>
-          <div class="media-content">
-            <div class="content">
-              <p>
-                <a
-                  href="https://www.themoviedb.org/movie/{{ movie.id }}"
-                  target="_blank"
-                  >{{ movie.title }}</a
-                >
-                <br />
-                <span *ngIf="!editing[movie.id]" (click)="enableEditing(movie)">
-                  {{ movie.release_date }} |
-                  <strong>
-                    {{ calculateReleasedYearsAgo(movie) }} year(s) ago
-                  </strong>
-                </span>
-                <input
-                  *ngIf="editing[movie.id]"
-                  type="text"
-                  [value]="movie.release_date"
-                  (keyup.enter)="updateReleaseDate($event, movie)"
-                  (blur)="disableEditing(movie)"
-                />
-
-                <br />
-                <br />
-                <button (click)="downloadICSCalendar(movie)" class="button">
-                  Download Calendar
-                </button>
-              </p>
-              <div class="bookmark-container">
-                <button
-                  class="transparent-button"
-                  (click)="toggleBookmark(movie)"
-                >
-                  <i
-                    class="fa-solid fa-bookmark"
-                    *ngIf="movie.isBookmarked"
-                  ></i>
-                  <i
-                    class="fa-regular fa-bookmark"
-                    *ngIf="!movie.isBookmarked"
-                  ></i>
-                </button>
-              </div>
-            </div>
-          </div>
-        </article>
+        </div>
       </div>
     </div>
   </div>
-  <h1 class="title is-size-4">Add bookmarked Movies</h1>
-  <div class="field is-grouped">
-    <div class="control custom">
+  <h2 class="title is-size-4 mt-6">Add Bookmarked Movies</h2>
+  <div class="field is-grouped mb-4 is-align-items-center">
+    <div class="control">
       <div class="select is-inline">
-        <select [(ngModel)]="selectedYear" (change)="onDateChange()">
+        <select [(ngModel)]="selectedYear" (change)="onDateChange()" class="custom-select">
           <option *ngFor="let year of years" [value]="year">{{ year }}</option>
         </select>
       </div>
@@ -102,55 +91,39 @@
       </button>
     </div>
   </div>
+
   <div class="columns is-multiline">
-    <div class="column is-half" *ngFor="let movie of films">
-      <div class="box">
-        <article class="media">
-          <div class="media-left">
-            <figure class="image is-96x96">
-              <img
-                [src]="
-                  'https://image.tmdb.org/t/p/original' + movie.poster_path
-                "
-                alt="{{ movie.title }}"
-                loading="lazy"
-              />
-            </figure>
+    <div class="column is-one-third" *ngFor="let movie of films">
+      <div class="card movie-card">
+        <div class="card-image">
+          <figure class="image is-2by3">
+            <img
+              [src]="'https://image.tmdb.org/t/p/original' + movie.poster_path"
+              alt="{{ movie.title }}"
+              loading="lazy"
+            />
+          </figure>
+        </div>
+        <div class="card-content">
+          <p class="title is-5">
+            <a href="https://www.themoviedb.org/movie/{{ movie.id }}" target="_blank"
+              >{{ movie.title }}</a
+            >
+          </p>
+          <p class="subtitle is-6">{{ movie.release_date }}</p>
+          <div class="buttons">
+            <button (click)="downloadICSCalendar(movie)" class="button is-small">
+              Download Calendar
+            </button>
+            <button
+              class="transparent-button"
+              (click)="addToggleBookmark(movie)"
+            >
+              <i class="fa-solid fa-bookmark" *ngIf="movie.isBookmarked"></i>
+              <i class="fa-regular fa-bookmark" *ngIf="!movie.isBookmarked"></i>
+            </button>
           </div>
-          <div class="media-content">
-            <div class="content">
-              <p>
-                <a
-                  href="https://www.themoviedb.org/movie/{{ movie.id }}"
-                  target="_blank"
-                  >{{ movie.title }}</a
-                >
-                <br />
-                {{ movie.release_date }}
-                <br />
-                <br />
-                <button (click)="downloadICSCalendar(movie)" class="button">
-                  Download Calendar
-                </button>
-              </p>
-              <div class="bookmark-container">
-                <button
-                  class="transparent-button"
-                  (click)="addToggleBookmark(movie)"
-                >
-                  <i
-                    class="fa-solid fa-bookmark"
-                    *ngIf="movie.isBookmarked"
-                  ></i>
-                  <i
-                    class="fa-regular fa-bookmark"
-                    *ngIf="!movie.isBookmarked"
-                  ></i>
-                </button>
-              </div>
-            </div>
-          </div>
-        </article>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- modernize the `calendar-detail` page layout
- show movies using Bulma cards
- add basic styling for new layout

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6a4845d483278e163554c702a5dd