### PR TITLE
Add calendar loading spinners

### DIFF
--- a/src/app/calendar/calendar.component.ts
+++ b/src/app/calendar/calendar.component.ts
@@ -33,7 +33,7 @@ import { DatabaseService } from '../service/database.service';
 })
 export class CalendarComponent implements OnInit {
   private _selectedView = 'Month';
-  loading = false;
+  loading = true;
   selectedMonth: number;
   selectedYear: number;
   selectedDate = new Date();
@@ -88,6 +88,7 @@ export class CalendarComponent implements OnInit {
 
   generateMonthCalendar(): void {
     // Clear the weeks array
+    this.loading = true;
     this.getFilms();
     this.weeks = [];
 

--- a/src/app/cast-crew/cast-crew.component.css
+++ b/src/app/cast-crew/cast-crew.component.css
@@ -188,6 +188,36 @@
   margin-bottom: 5px;
 }
 
+.loading-animation {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.spinner {
+  border: 16px solid #f3f3f3;
+  border-top: 16px solid #3498db;
+  border-radius: 50%;
+  width: 120px;
+  height: 120px;
+  animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
 .weekend-day {
   background-color: #f5f5f5;
 }

--- a/src/app/cast-crew/cast-crew.component.html
+++ b/src/app/cast-crew/cast-crew.component.html
@@ -1,5 +1,9 @@
-<div class="container">
-  <div class="calendar">
+<div *ngIf="loading" class="loading-animation">
+  <div class="spinner"></div>
+</div>
+<div *ngIf="!loading">
+  <div class="container">
+    <div class="calendar">
     <div class="date-selector">
       <div class="field is-grouped">
         <div class="control">

--- a/src/app/cast-crew/cast-crew.component.ts
+++ b/src/app/cast-crew/cast-crew.component.ts
@@ -35,6 +35,8 @@ import { CastCrew } from '../cast-crew';
 export class CastCrewComponent implements OnInit {
   private _selectedView = 'Month';
 
+  loading = true;
+
   selectedMonth: number;
   selectedYear: number;
   selectedDate = new Date();
@@ -85,6 +87,7 @@ export class CastCrewComponent implements OnInit {
   }
 
   async getCastCrew() {
+    this.loading = true;
     this.actors = await this.databaseService.getActors();
     this.actresses = await this.databaseService.getAcresses();
     this.directors = await this.databaseService.getDirectors();
@@ -96,14 +99,15 @@ export class CastCrewComponent implements OnInit {
     this.allcastCrew = this.allcastCrew.concat(this.composers);
     //remove duplicates from allcastCrew
     this.allcastCrew = this.allcastCrew.filter(
-      (thing, index, self) =>
-        index === self.findIndex((t) => t.Title === thing.Title)
+      (thing, index, self) => index === self.findIndex((t) => t.Title === thing.Title)
     );
 
+    this.loading = false;
   }
 
   generateMonthCalendar(): void {
     // Clear the weeks array
+    this.loading = true;
     this.weeks = [];
     this.getCastCrew();
 
@@ -166,7 +170,9 @@ export class CastCrewComponent implements OnInit {
 
   generateWeekCalendar(): void {
     // Clear the weeks array
+    this.loading = true;
     this.weeks = [];
+    this.getCastCrew();
 
     // Assume that selectedDate is the date around which you want to build your week view.
     const startDate = new Date(this.selectedDate);


### PR DESCRIPTION
## Summary
- show spinner while movies calendar loads
- add loading spinner support to cast & crew calendar

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d74792f9483279e7cd092993f4881