### PR TITLE
Highlight current day in calendar

### DIFF
--- a/src/app/calendar/calendar.component.css
+++ b/src/app/calendar/calendar.component.css
@@ -177,7 +177,8 @@
 }
 
 .today {
-  background-color: rgb(207, 206, 206); /* Or whatever color you prefer */
+  background-color: #4a4a4a; /* Darker shade for current day */
+  color: #ffffff;
 }
 
 .bookmarked-movie {

--- a/src/app/cast-crew/cast-crew.component.css
+++ b/src/app/cast-crew/cast-crew.component.css
@@ -177,7 +177,8 @@
 }
 
 .today {
-  background-color: rgb(207, 206, 206); /* Or whatever color you prefer */
+  background-color: #4a4a4a; /* Darker shade for current day */
+  color: #ffffff;
 }
 
 .bookmarked-movie {


### PR DESCRIPTION
## Summary
- mark the current day with a darker style in movie and cast & crew calendars

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e825c625c83279ebfb617758912a7