### PR TITLE
Redesign Day Detail view to Modern Minimal

### DIFF
--- a/src/app/calendar-detail/calendar-detail.component.css
+++ b/src/app/calendar-detail/calendar-detail.component.css
@@ -1,43 +1,456 @@
-.custom-image {
-  width: 80px; /* Adjust to your preferred width */
-  height: 80px; /* Adjust to your preferred height */
+.fe-detail {
+  font-family: var(--font-ui);
+  color: var(--text);
 }
 
-.text-center {
-  text-align: center;
-}
-
-.media-content {
-  position: relative; /* Position relative for bookmark-container */
-}
-
-.bookmark-container {
-  position: absolute;
-  top: 0;
-  right: 0;
-  margin-top: 5px; /* Adjust top margin for spacing */
-}
-
-.transparent-button {
-  background-color: transparent;
-  border: none; /* Optionally, remove the button border */
-  padding: 0; /* Optionally, remove padding to make it as small as possible */
-}
-
-.custom {
-  padding-right: 33%;
-}
-
-.control {
+/* Header */
+.fe-detail__header {
   display: flex;
-  justify-content: space-between; /* Positions the buttons at opposite ends */
-  align-items: center; /* Centers them vertically if there's extra height */
-  margin-bottom: 25px;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 40px var(--page-x) 0;
 }
 
-/* Mobile adjustments */
-@media (max-width: 768px) {
-  .custom {
-    padding-right: 0;
+.fe-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.fe-breadcrumb__back {
+  color: var(--red);
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.fe-breadcrumb__back:hover {
+  color: var(--red-ink);
+}
+
+.fe-breadcrumb__sep {
+  color: var(--muted);
+}
+
+.fe-breadcrumb__meta {
+  color: var(--text-muted);
+}
+
+.fe-h1 {
+  font-family: var(--font-serif);
+  font-size: 64px;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 1.02;
+  margin: 8px 0 0;
+}
+
+.fe-h1__month {
+  color: var(--muted);
+  font-weight: 400;
+}
+
+.fe-h1__day {
+  color: var(--text);
+}
+
+.fe-h1__dot {
+  color: var(--red);
+  font-style: italic;
+}
+
+.fe-detail__daynav {
+  display: flex;
+  gap: 8px;
+  flex: none;
+}
+
+.fe-textbtn {
+  min-height: 34px;
+  padding: 8px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.fe-textbtn:hover {
+  border-color: var(--border-strong);
+}
+
+/* Grid */
+.fe-detail__grid {
+  display: grid;
+  grid-template-columns: 1.05fr 1fr;
+  gap: 48px;
+  padding: 36px var(--page-x) 48px;
+}
+
+.fe-section__title {
+  font-family: var(--font-serif);
+  font-size: 26px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  margin: 0 0 16px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.fe-section__count {
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--muted);
+}
+
+.fe-loading-inline,
+.fe-empty {
+  color: var(--muted);
+  font-size: 13px;
+  padding: 8px 0;
+}
+
+/* Watchlist controls */
+.fe-watch-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.fe-watch-filters {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.fe-select {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 26px 7px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--chip-radius);
+  background: var(--surface);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.fe-select__label {
+  color: var(--text);
+}
+
+.fe-select select {
+  border: none;
+  background: transparent;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text);
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 2px;
+}
+
+.fe-select select:focus {
+  outline: none;
+}
+
+.fe-select__caret {
+  position: absolute;
+  right: 12px;
+  font-size: 10px;
+  color: var(--muted);
+  pointer-events: none;
+}
+
+.fe-chip-wrap {
+  position: relative;
+}
+
+.fe-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border-radius: var(--chip-radius);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 150ms ease, border-color 150ms ease;
+}
+
+.fe-chip.is-active {
+  background: var(--red-soft);
+  border-color: var(--red);
+  color: var(--red-ink);
+}
+
+.fe-chip__caret {
+  font-size: 10px;
+  color: var(--muted);
+}
+
+.fe-menu {
+  position: absolute;
+  top: 38px;
+  left: 0;
+  min-width: 160px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
+  padding: 4px;
+  z-index: 30;
+}
+
+.fe-menu__item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 8px 10px;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.fe-menu__item:hover {
+  background: var(--bg);
+}
+
+.fe-pager {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.fe-pager__label {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.fe-iconbtn {
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.fe-iconbtn:hover {
+  border-color: var(--border-strong);
+}
+
+/* Cards */
+.fe-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.fe-card {
+  display: flex;
+  gap: 16px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--card-radius);
+  background: var(--surface);
+}
+
+.fe-card__poster {
+  flex: none;
+  width: 72px;
+  height: 104px;
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--elev);
+}
+
+.fe-card__poster img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.fe-card__poster.is-empty {
+  display: flex;
+  align-items: flex-end;
+  background: repeating-linear-gradient(
+    -45deg,
+    var(--elev),
+    var(--elev) 6px,
+    var(--border) 6px,
+    var(--border) 12px
+  );
+}
+
+.fe-card__poster-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+  padding: 6px;
+}
+
+.fe-card__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.fe-card__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.fe-card__title {
+  font-family: var(--font-serif);
+  font-size: 20px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  margin: 0;
+  color: var(--text);
+}
+
+.fe-bm {
+  flex: none;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 150ms ease, background-color 150ms ease;
+}
+
+.fe-bm:hover {
+  transform: scale(1.1);
+}
+
+.fe-bm.is-on {
+  background: var(--red);
+  border-color: var(--red);
+  color: #fff;
+}
+
+.fe-card__meta {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 6px;
+}
+
+.fe-card__meta-sep {
+  color: var(--muted);
+  margin: 0 2px;
+}
+
+.fe-card__meta .is-anniv {
+  color: var(--red);
+  font-weight: 600;
+}
+
+.fe-card__tags {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.fe-tag {
+  padding: 3px 8px;
+  border-radius: var(--chip-radius);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.fe-tag--rating {
+  font-family: var(--font-mono);
+}
+
+.fe-card__actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.fe-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border-radius: 6px;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  border: 1px solid transparent;
+}
+
+.fe-btn--solid {
+  background: var(--text);
+  color: var(--surface);
+}
+
+.fe-btn--solid:hover {
+  opacity: 0.9;
+}
+
+.fe-btn--ghost {
+  background: var(--surface);
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.fe-btn--ghost:hover {
+  border-color: var(--border-strong);
+}
+
+/* Responsive */
+@media (max-width: 900px) {
+  .fe-detail__header {
+    flex-direction: column;
+    gap: 16px;
+    padding: 24px 20px 0;
+  }
+
+  .fe-h1 {
+    font-size: 48px;
+  }
+
+  .fe-detail__grid {
+    grid-template-columns: 1fr;
+    gap: 32px;
+    padding: 24px 20px 40px;
   }
 }

--- a/src/app/calendar-detail/calendar-detail.component.html
+++ b/src/app/calendar-detail/calendar-detail.component.html
@@ -1,157 +1,164 @@
-<div class="container">
-  <h1 class="title is-size-3">{{ date }}</h1>
-  <h1 class="title is-size-4">Bookmarked Movies</h1>
-  <div class="control">
-    <button (click)="onDateChangePrevious()" class="button left">
-      <i class="fas fa-arrow-left"></i>
-    </button>
-    <button (click)="onDateChangeNext()" class="button right">
-      <i class="fas fa-arrow-right"></i>
-    </button>
-  </div>
-
-  <div *ngIf="isLoadingBookmarked" class="has-text-centered">
-    <button class="button is-large is-loading is-white">
-      Loading Bookmarked Movies...
-    </button>
-  </div>
-
-  <div class="columns is-multiline">
-    <div class="column is-half" *ngFor="let movie of bookmarkedMovies">
-      <div class="box">
-        <article class="media">
-          <div class="media-left">
-            <figure class="image is-96x96">
-              <img
-                [src]="
-                  'https://image.tmdb.org/t/p/original' + movie.poster_path
-                "
-                alt="{{ movie.title }}"
-              />
-            </figure>
-          </div>
-          <div class="media-content">
-            <div class="content">
-              <p>
-                <a
-                  href="https://www.themoviedb.org/movie/{{ movie.id }}"
-                  target="_blank"
-                  >{{ movie.title }}</a
-                >
-                <br />
-                <span *ngIf="!editing[movie.id]" (click)="enableEditing(movie)">
-                  {{ movie.release_date }} |
-                  <strong>
-                    {{ calculateReleasedYearsAgo(movie) }} year(s) ago
-                  </strong>
-                </span>
-                <input
-                  *ngIf="editing[movie.id]"
-                  type="text"
-                  [value]="movie.release_date"
-                  (keyup.enter)="updateReleaseDate($event, movie)"
-                  (blur)="disableEditing(movie)"
-                />
-
-                <br />
-                <br />
-                <button (click)="downloadICSCalendar(movie)" class="button">
-                  Download Calendar
-                </button>
-              </p>
-              <div class="bookmark-container">
-                <button
-                  class="transparent-button"
-                  (click)="toggleBookmark(movie)"
-                >
-                  <i
-                    class="fa-solid fa-bookmark"
-                    *ngIf="movie.isBookmarked"
-                  ></i>
-                  <i
-                    class="fa-regular fa-bookmark"
-                    *ngIf="!movie.isBookmarked"
-                  ></i>
-                </button>
-              </div>
-            </div>
-          </div>
-        </article>
+<div class="fe-detail">
+  <!-- Header -->
+  <header class="fe-detail__header">
+    <div class="fe-detail__head-left">
+      <div class="fe-breadcrumb">
+        <a [routerLink]="['/home']" class="fe-breadcrumb__back">
+          ← {{ monthName }} {{ headerYear }}
+        </a>
+        <span class="fe-breadcrumb__sep">·</span>
+        <span class="fe-breadcrumb__meta">{{ weekdayName }} · Week {{ weekNumber }}</span>
       </div>
-    </div>
-  </div>
-  <h1 class="title is-size-4">Add bookmarked Movies</h1>
-  <div class="field is-grouped">
-    <div class="control custom">
-      <div class="select is-inline">
-        <select [(ngModel)]="selectedYear" (change)="onDateChange()">
-          <option *ngFor="let year of years" [value]="year">{{ year }}</option>
-        </select>
-      </div>
+      <h1 class="fe-h1">
+        <span class="fe-h1__month">{{ monthName }}</span>
+        <span class="fe-h1__day">{{ dayNumber }}</span><i class="fe-h1__dot">.</i>
+      </h1>
     </div>
 
-    <div class="control" style="margin-left: 55px">
-      <button (click)="previousPage()" class="button">
-        <i class="fas fa-arrow-left"></i>
+    <div class="fe-detail__daynav">
+      <button class="fe-textbtn" (click)="onDateChangePrevious()" aria-label="Previous day">
+        ‹ {{ prevDayLabel }}
+      </button>
+      <button class="fe-textbtn" (click)="onDateChangeNext()" aria-label="Next day">
+        {{ nextDayLabel }} ›
       </button>
     </div>
-    <div class="control">{{ result.page }}/{{ result.total_pages }}</div>
-    <div class="control">
-      <button (click)="nextPage()" class="button">
-        <i class="fas fa-arrow-right"></i>
-      </button>
-    </div>
-  </div>
-  <div class="columns is-multiline">
-    <div class="column is-half" *ngFor="let movie of films">
-      <div class="box">
-        <article class="media">
-          <div class="media-left">
-            <figure class="image is-96x96">
-              <img
-                [src]="
-                  'https://image.tmdb.org/t/p/original' + movie.poster_path
-                "
-                alt="{{ movie.title }}"
-                loading="lazy"
-              />
-            </figure>
-          </div>
-          <div class="media-content">
-            <div class="content">
-              <p>
-                <a
-                  href="https://www.themoviedb.org/movie/{{ movie.id }}"
-                  target="_blank"
-                  >{{ movie.title }}</a
-                >
-                <br />
-                {{ movie.release_date }}
-                <br />
-                <br />
-                <button (click)="downloadICSCalendar(movie)" class="button">
-                  Download Calendar
-                </button>
-              </p>
-              <div class="bookmark-container">
-                <button
-                  class="transparent-button"
-                  (click)="addToggleBookmark(movie)"
-                >
-                  <i
-                    class="fa-solid fa-bookmark"
-                    *ngIf="movie.isBookmarked"
-                  ></i>
-                  <i
-                    class="fa-regular fa-bookmark"
-                    *ngIf="!movie.isBookmarked"
-                  ></i>
-                </button>
-              </div>
+  </header>
+
+  <!-- Two-column grid -->
+  <div class="fe-detail__grid">
+    <!-- Left: Your bookmarks -->
+    <section class="fe-col">
+      <h2 class="fe-section__title">
+        Your bookmarks
+        <span class="fe-section__count">{{ bookmarkedMovies.length }} anniversaries</span>
+      </h2>
+
+      <div *ngIf="isLoadingBookmarked" class="fe-loading-inline">Loading bookmarks…</div>
+
+      <div class="fe-cards">
+        <ng-container *ngFor="let movie of bookmarkedMovies">
+          <ng-container
+            *ngTemplateOutlet="card; context: { movie: movie, watchlist: false }"
+          ></ng-container>
+        </ng-container>
+        <p
+          *ngIf="!isLoadingBookmarked && bookmarkedMovies.length === 0"
+          class="fe-empty"
+        >
+          No bookmarked anniversaries on this day.
+        </p>
+      </div>
+    </section>
+
+    <!-- Right: Add to watchlist -->
+    <section class="fe-col">
+      <h2 class="fe-section__title">
+        Add to watchlist
+        <span class="fe-section__count">Releases on {{ watchlistDateLabel }}</span>
+      </h2>
+
+      <div class="fe-watch-controls">
+        <div class="fe-watch-filters">
+          <label class="fe-select">
+            <span class="fe-select__label">Year:</span>
+            <select [(ngModel)]="selectedYear" (change)="onDateChange()">
+              <option *ngFor="let y of years" [value]="y">{{ y }}</option>
+            </select>
+            <span class="fe-select__caret">⌄</span>
+          </label>
+
+          <div class="fe-chip-wrap">
+            <button
+              class="fe-chip"
+              [class.is-active]="watchlistGenre"
+              (click)="toggleGenreMenu()"
+            >
+              Genre: {{ watchlistGenre || 'All' }}
+              <span class="fe-chip__caret">⌄</span>
+            </button>
+            <div class="fe-menu" *ngIf="genreMenuOpen">
+              <button class="fe-menu__item" (click)="setWatchlistGenre(null)">All</button>
+              <button
+                class="fe-menu__item"
+                *ngFor="let g of availableWatchlistGenres()"
+                (click)="setWatchlistGenre(g)"
+              >
+                {{ g }}
+              </button>
             </div>
           </div>
-        </article>
+        </div>
+
+        <div class="fe-pager">
+          <button class="fe-iconbtn" (click)="previousPage()" aria-label="Previous page">‹</button>
+          <span class="fe-pager__label">{{ result.page }} / {{ result.total_pages }}</span>
+          <button class="fe-iconbtn" (click)="nextPage()" aria-label="Next page">›</button>
+        </div>
       </div>
-    </div>
+
+      <div class="fe-cards">
+        <ng-container *ngFor="let movie of filteredFilms">
+          <ng-container
+            *ngTemplateOutlet="card; context: { movie: movie, watchlist: true }"
+          ></ng-container>
+        </ng-container>
+        <p *ngIf="filteredFilms.length === 0" class="fe-empty">
+          No releases match this filter.
+        </p>
+      </div>
+    </section>
   </div>
 </div>
+
+<!-- Shared movie card -->
+<ng-template #card let-movie="movie" let-watchlist="watchlist">
+  <article class="fe-card">
+    <div class="fe-card__poster" [class.is-empty]="!posterUrl(movie)">
+      <img
+        *ngIf="posterUrl(movie)"
+        [src]="posterUrl(movie)"
+        alt="{{ movie.title }} poster"
+        loading="lazy"
+      />
+      <span *ngIf="!posterUrl(movie)" class="fe-card__poster-label">{{
+        posterInitials(movie)
+      }}</span>
+    </div>
+
+    <div class="fe-card__body">
+      <div class="fe-card__top">
+        <h3 class="fe-card__title">{{ movie.title }}</h3>
+        <button
+          class="fe-bm"
+          [class.is-on]="movie.isBookmarked"
+          [attr.aria-label]="(movie.isBookmarked ? 'Bookmarked ' : 'Bookmark ') + movie.title"
+          (click)="watchlist ? addToggleBookmark(movie) : toggleBookmark(movie)"
+        >
+          <i class="fa-solid fa-bookmark" *ngIf="movie.isBookmarked"></i>
+          <i class="fa-regular fa-bookmark" *ngIf="!movie.isBookmarked"></i>
+        </button>
+      </div>
+
+      <div class="fe-card__meta">
+        {{ movie.release_date | date: 'yyyy' }}
+        <span class="fe-card__meta-sep">·</span>
+        <span class="is-anniv">{{ calculateReleasedYearsAgo(movie) }} years ago today</span>
+      </div>
+
+      <div class="fe-card__tags">
+        <span class="fe-tag">{{ genreLabel(movie) }}</span>
+        <span class="fe-tag fe-tag--rating">★ {{ movie.vote_average | number: '1.1-1' }}</span>
+      </div>
+
+      <div class="fe-card__actions">
+        <button class="fe-btn fe-btn--solid" (click)="downloadICSCalendar(movie)">
+          <i class="fas fa-download"></i> Add to calendar
+        </button>
+        <a class="fe-btn fe-btn--ghost" [href]="tmdbUrl(movie)" target="_blank" rel="noopener">
+          Details
+        </a>
+      </div>
+    </div>
+  </article>
+</ng-template>

--- a/src/app/calendar-detail/calendar-detail.component.ts
+++ b/src/app/calendar-detail/calendar-detail.component.ts
@@ -2,10 +2,25 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MoviedatabaseService } from '../service/moviedatabase.service';
 import { IFilm, Result } from '../filmresult';
-import { BookmarkService } from '../service/bookmarked.service';
 import { ICalendar } from 'datebook';
 import { SelectdateService } from '../service/selectdate.service';
 import { DatabaseService } from '../service/database.service';
+import { genreName, genreBucket, GenreBucket } from '../genres';
+
+export function getIsoWeek(date: Date): number {
+  // ISO-8601 week number (weeks start Monday; week 1 contains the first Thursday).
+  const d = new Date(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
+  );
+  const dayNum = (d.getUTCDay() + 6) % 7; // Mon=0 .. Sun=6
+  d.setUTCDate(d.getUTCDate() - dayNum + 3); // nearest Thursday
+  const firstThursday = new Date(Date.UTC(d.getUTCFullYear(), 0, 4));
+  const firstDayNum = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstDayNum + 3);
+  return (
+    1 + Math.round((d.getTime() - firstThursday.getTime()) / (7 * 24 * 3600 * 1000))
+  );
+}
 
 @Component({
   selector: 'app-calendar-detail',
@@ -15,21 +30,32 @@ import { DatabaseService } from '../service/database.service';
 export class CalendarDetailComponent implements OnInit {
   selectedYear!: number;
   bookmarkedMovies: IFilm[] = [];
-  isLoadingBookmarked = false; // <-- NEW FLAG
+  isLoadingBookmarked = false;
 
   years: number[] = Array.from(
     { length: 61 },
     (_, i) => new Date().getFullYear() - 60 + i
-  );
+  ).reverse();
+
+  months: string[] = [
+    'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December',
+  ];
+  weekdays: string[] = [
+    'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday',
+  ];
+
   date = '';
   films: IFilm[] = [];
   result: Result = { page: 1, total_pages: 1, results: [], total_results: 0 };
-  editing: { [key: string]: boolean } = {};
+
+  // Watchlist genre filter (client-side, within the current page).
+  watchlistGenre: GenreBucket | null = null;
+  genreMenuOpen = false;
 
   constructor(
     private route: ActivatedRoute,
     private movieService: MoviedatabaseService,
-    //private bookmarkService: BookmarkService,
     private dateService: SelectdateService,
     private databaseService: DatabaseService,
     private router: Router
@@ -37,52 +63,125 @@ export class CalendarDetailComponent implements OnInit {
 
   ngOnInit(): void {
     this.route.params.subscribe((params) => {
-      this.date = params['date']; // Access the 'date' parameter
+      this.date = params['date'];
       this.selectedYear = Number(this.date.substring(0, 4));
 
-      // Extract the month and day from the date parameter
       const selectedMonthDay = this.date.substring(5);
 
-      // Get all bookmarked movies from the database
       this.getDatabaseFilms().then(() => {
-        // Filter the bookmarkedMovies array to only include movies released on the selected day and month
-        this.bookmarkedMovies = this.bookmarkedMovies.filter((movie) => {
-          const movieMonthDay = movie.release_date.substring(5);
-          return movieMonthDay === selectedMonthDay;
-        });
+        this.bookmarkedMovies = this.bookmarkedMovies.filter(
+          (movie) => movie.release_date.substring(5) === selectedMonthDay
+        );
       });
 
+      this.watchlistGenre = null;
       this.getFilms(1);
     });
   }
 
-  enableEditing(movie: IFilm) {
-    this.editing[movie.id] = true;
+  // ----- Header view-model (computed from this.date) -----
+
+  private dateObj(offsetDays = 0): Date {
+    const [y, m, d] = this.date.split('-').map((p) => parseInt(p, 10));
+    const dt = new Date(y, m - 1, d);
+    if (offsetDays) dt.setDate(dt.getDate() + offsetDays);
+    return dt;
   }
 
-  disableEditing(movie: IFilm) {
-    this.editing[movie.id] = false;
+  get monthName(): string {
+    return this.months[this.dateObj().getMonth()];
   }
 
-  updateReleaseDate(event: any, movie: IFilm) {
-    const newDate = event.target.value;
-    movie.release_date = newDate;
-    this.disableEditing(movie);
-    if (movie._id) {
-      this.databaseService.updateFilm(movie._id.toString(), movie);
-    }
+  get dayNumber(): number {
+    return this.dateObj().getDate();
+  }
+
+  get headerYear(): number {
+    return this.dateObj().getFullYear();
+  }
+
+  get weekdayName(): string {
+    return this.weekdays[this.dateObj().getDay()];
+  }
+
+  get weekNumber(): number {
+    return getIsoWeek(this.dateObj());
+  }
+
+  private dayLabel(offsetDays: number): string {
+    const d = this.dateObj(offsetDays);
+    return `${this.months[d.getMonth()]} ${d.getDate()}`;
+  }
+
+  get prevDayLabel(): string {
+    return this.dayLabel(-1);
+  }
+
+  get nextDayLabel(): string {
+    return this.dayLabel(1);
+  }
+
+  get watchlistDateLabel(): string {
+    return `${this.monthName} ${this.dayNumber}`;
+  }
+
+  // ----- Card display helpers -----
+
+  posterUrl(movie: IFilm): string | null {
+    return movie.poster_path
+      ? `https://image.tmdb.org/t/p/w185${movie.poster_path}`
+      : null;
+  }
+
+  posterInitials(movie: IFilm): string {
+    const letters = (movie.title || '')
+      .replace(/[^a-zA-Z0-9 ]/g, '')
+      .replace(/\s+/g, '')
+      .slice(0, 4);
+    return (letters || '?').toUpperCase();
+  }
+
+  genreLabel(movie: IFilm): string {
+    return genreName(movie);
   }
 
   calculateReleasedYearsAgo(movie: IFilm): number {
     const releaseYear = new Date(movie.release_date).getFullYear();
-    const currentYear = new Date().getFullYear();
-    return currentYear - releaseYear;
+    return new Date().getFullYear() - releaseYear;
   }
 
+  tmdbUrl(movie: IFilm): string {
+    return `https://www.themoviedb.org/movie/${movie.id}`;
+  }
+
+  // ----- Watchlist genre filter -----
+
+  get filteredFilms(): IFilm[] {
+    if (!this.watchlistGenre) return this.films;
+    return this.films.filter((m) => genreBucket(m) === this.watchlistGenre);
+  }
+
+  availableWatchlistGenres(): GenreBucket[] {
+    const set = new Set<GenreBucket>();
+    this.films.forEach((m) => set.add(genreBucket(m)));
+    return Array.from(set).sort();
+  }
+
+  toggleGenreMenu(): void {
+    this.genreMenuOpen = !this.genreMenuOpen;
+  }
+
+  setWatchlistGenre(g: GenreBucket | null): void {
+    this.watchlistGenre = g;
+    this.genreMenuOpen = false;
+  }
+
+  // ----- Data -----
+
   async getDatabaseFilms() {
-    this.isLoadingBookmarked = true; // <-- TURN ON LOADING
+    this.isLoadingBookmarked = true;
     this.bookmarkedMovies = (await this.databaseService.getAllFilms()) || [];
-    this.isLoadingBookmarked = false; // <-- TURN OFF LOADING
+    this.isLoadingBookmarked = false;
   }
 
   async getFilms(id: number) {
@@ -92,6 +191,7 @@ export class CalendarDetailComponent implements OnInit {
     );
   }
 
+  // Toggle bookmark on a film already stored in our DB (left column).
   toggleBookmark(movie: IFilm) {
     movie.isBookmarked = !movie.isBookmarked;
     if (movie._id) {
@@ -99,8 +199,40 @@ export class CalendarDetailComponent implements OnInit {
     }
   }
 
-  //TODO: add toggleBookmark for new movies
-  addToggleBookmark(movie: IFilm) {}
+  // Add a TMDB release to the DB as a bookmark (right column).
+  // Mirrors navbar.component.ts#toggleBookmark create flow.
+  async addToggleBookmark(movie: IFilm) {
+    if (movie.isBookmarked) return;
+    try {
+      const releaseData = await this.movieService.getReleaseDates(movie.id);
+      const usReleaseData = releaseData.results.find(
+        (result) => result.iso_3166_1 === 'US'
+      );
+
+      if (usReleaseData) {
+        let usReleaseDates = usReleaseData.release_dates.filter(
+          (d) => d.type === 3
+        );
+        if (usReleaseDates.length === 0) {
+          usReleaseDates = usReleaseData.release_dates.filter(
+            (d) => d.type === 4
+          );
+        }
+        if (usReleaseDates.length > 0) {
+          movie.release_date = new Date(usReleaseDates[0].release_date)
+            .toISOString()
+            .split('T')[0];
+        }
+      }
+
+      movie.isBookmarked = true;
+      await this.databaseService.createFilm(movie);
+    } catch (error) {
+      movie.isBookmarked = false;
+    }
+  }
+
+  // ----- Day / page navigation -----
 
   onDateChange() {
     this.date = this.selectedYear + this.date.substring(4);
@@ -109,61 +241,25 @@ export class CalendarDetailComponent implements OnInit {
     const year = parseInt(dateParts[0]);
     const month = parseInt(dateParts[1]) - 1;
     const day = parseInt(dateParts[2]);
-    const newDate = new Date(year, month, day);
-
-    this.dateService.selectedDate = newDate;
+    this.dateService.selectedDate = new Date(year, month, day);
+    this.watchlistGenre = null;
     this.getFilms(1);
   }
 
-  //change date for page to next day
   onDateChangeNext() {
-    const dateParts = this.date.split('-');
-    const year = parseInt(dateParts[0], 10);
-    const month = parseInt(dateParts[1], 10) - 1; // JavaScript months are 0-based
-    const day = parseInt(dateParts[2], 10);
-
-    // Create a new Date object and add one day
-    const currentDate = new Date(year, month, day);
-    currentDate.setDate(currentDate.getDate() + 1);
-
-    // Format the new date as YYYY-MM-DD
-    const newYear = currentDate.getFullYear();
-    const newMonth = (currentDate.getMonth() + 1).toString().padStart(2, '0');
-    const newDay = currentDate.getDate().toString().padStart(2, '0');
-
-    const nextDate = `${newYear}-${newMonth}-${newDay}`;
-
-    // Navigate to the new URL
-    this.router.navigate(['/detail', nextDate]).then(() => {
-      // Update local variables if necessary
-      this.date = nextDate;
-      this.selectedYear = newYear;
-    });
+    this.navigateToDay(1);
   }
 
   onDateChangePrevious() {
-    const dateParts = this.date.split('-');
-    const year = parseInt(dateParts[0], 10);
-    const month = parseInt(dateParts[1], 10) - 1; // JavaScript months are 0-based
-    const day = parseInt(dateParts[2], 10);
+    this.navigateToDay(-1);
+  }
 
-    // Create a new Date object and subtract one day
-    const currentDate = new Date(year, month, day);
-    currentDate.setDate(currentDate.getDate() - 1);
-
-    // Format the new date as YYYY-MM-DD
-    const newYear = currentDate.getFullYear();
-    const newMonth = (currentDate.getMonth() + 1).toString().padStart(2, '0');
-    const newDay = currentDate.getDate().toString().padStart(2, '0');
-
-    const previousDate = `${newYear}-${newMonth}-${newDay}`;
-
-    // Navigate to the new URL
-    this.router.navigate(['/detail', previousDate]).then(() => {
-      // Update local variables if necessary
-      this.date = previousDate;
-      this.selectedYear = newYear;
-    });
+  private navigateToDay(offsetDays: number) {
+    const next = this.dateObj(offsetDays);
+    const y = next.getFullYear();
+    const m = (next.getMonth() + 1).toString().padStart(2, '0');
+    const d = next.getDate().toString().padStart(2, '0');
+    this.router.navigate(['/detail', `${y}-${m}-${d}`]);
   }
 
   previousPage() {
@@ -202,34 +298,5 @@ export class CalendarDetailComponent implements OnInit {
     document.body.appendChild(downloadLink);
     downloadLink.click();
     document.body.removeChild(downloadLink);
-  }
-
-  generateICSCalendar(film: IFilm): string {
-    const eventDate = new Date(this.date);
-    const eventYear = eventDate.getFullYear();
-    const eventMonth = (eventDate.getMonth() + 1).toString().padStart(2, '0');
-    const eventDay = eventDate.getDate().toString().padStart(2, '0');
-    const formattedDate = `${eventYear}${eventMonth}${eventDay}`;
-    const eventName = film.title;
-    const uid = '1234567890';
-    const dtstamp = new Date()
-      .toISOString()
-      .replace(/[-:]/g, '')
-      .replace(/\.\d{3}Z/, 'Z');
-
-    const icsContent = `
-    BEGIN:VCALENDAR
-    VERSION:2.0
-    PRODID:My Angular Calendar App
-    BEGIN:VEVENT
-    DTSTAMP:${dtstamp}
-    DTSTART:${formattedDate}T000000Z
-    DTEND:${formattedDate}T235959Z
-    SUMMARY:${eventName}
-    UID:${uid}
-    END:VEVENT
-    END:VCALENDAR
-  `;
-    return icsContent;
   }
 }

--- a/src/app/calendar-detail/calendar-detail.spec.ts
+++ b/src/app/calendar-detail/calendar-detail.spec.ts
@@ -1,0 +1,16 @@
+import { getIsoWeek } from './calendar-detail.component';
+
+describe('getIsoWeek', () => {
+  it('returns week 1 for a Jan-1 Thursday (2026-01-01)', () => {
+    expect(getIsoWeek(new Date(2026, 0, 1))).toBe(1);
+  });
+
+  it('returns week 23 for 2026-06-05 (matches the design)', () => {
+    expect(getIsoWeek(new Date(2026, 5, 5))).toBe(23);
+  });
+
+  it('treats Monday as the start of the week', () => {
+    // 2026-06-08 is the Monday of the following ISO week.
+    expect(getIsoWeek(new Date(2026, 5, 8))).toBe(24);
+  });
+});


### PR DESCRIPTION
Two-column layout (Your bookmarks / Add to watchlist) using the shared design tokens. Adds breadcrumb + "Month Day." header with day nav, genre/rating tag pills, striped poster placeholder fallback, a working client-side genre filter on the watchlist, and wires the watchlist bookmark button to persist via the navbar's create flow. Drops the old Bulma markup and the unused inline release-date edit. Adds an ISO week-number helper + spec.