### PR TITLE
Redesign Cast & Crew to Modern Minimal

### DIFF
--- a/src/app/cast-crew-detail/cast-crew-detail.component.css
+++ b/src/app/cast-crew-detail/cast-crew-detail.component.css
@@ -1,0 +1,202 @@
+.fe-bday {
+  font-family: var(--font-ui);
+  color: var(--text);
+}
+
+/* Header */
+.fe-bday__header {
+  padding: 40px var(--page-x) 0;
+}
+
+.fe-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.fe-breadcrumb__back {
+  color: var(--red);
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.fe-breadcrumb__back:hover {
+  color: var(--red-ink);
+}
+
+.fe-breadcrumb__sep {
+  color: var(--muted);
+}
+
+.fe-breadcrumb__meta {
+  color: var(--text-muted);
+}
+
+.fe-h1 {
+  font-family: var(--font-serif);
+  font-size: 56px;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+  margin: 8px 0 0;
+  color: var(--text);
+}
+
+.fe-h1__accent {
+  font-style: italic;
+  color: var(--red);
+}
+
+.fe-bday__subtitle {
+  font-size: 14px;
+  color: var(--text-muted);
+  margin: 12px 0 0;
+  min-height: 18px;
+}
+
+.fe-loading-inline,
+.fe-empty {
+  color: var(--muted);
+  font-size: 13px;
+  padding: 8px var(--page-x);
+}
+
+/* Cards grid */
+.fe-bday__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  padding: 28px var(--page-x) 48px;
+}
+
+.fe-person {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--card-radius);
+  background: var(--surface);
+}
+
+.fe-person__avatar {
+  flex: none;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #efe7d7, #d6cdbb);
+}
+
+:root[data-theme='dark'] .fe-person__avatar {
+  background: linear-gradient(135deg, var(--elev), var(--border-strong));
+}
+
+.fe-person__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.fe-person__initials {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 22px;
+  color: var(--text-muted);
+}
+
+.fe-person__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.fe-person__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.fe-person__name {
+  font-family: var(--font-serif);
+  font-size: 20px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  margin: 0;
+  color: var(--text);
+}
+
+.fe-person__badge {
+  flex: none;
+  padding: 3px 8px;
+  border-radius: var(--chip-radius);
+  background: var(--red-soft);
+  color: var(--red-ink);
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.fe-person__sub {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.fe-person__actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.fe-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border-radius: 6px;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  border: 1px solid transparent;
+}
+
+.fe-btn--solid {
+  background: var(--text);
+  color: var(--surface);
+}
+
+.fe-btn--solid:hover {
+  opacity: 0.9;
+}
+
+.fe-btn--ghost {
+  background: var(--surface);
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.fe-btn--ghost:hover {
+  border-color: var(--border-strong);
+}
+
+/* Responsive */
+@media (max-width: 900px) {
+  .fe-bday__header {
+    padding: 24px 20px 0;
+  }
+  .fe-h1 {
+    font-size: 40px;
+  }
+  .fe-bday__grid {
+    grid-template-columns: 1fr;
+    padding: 20px 20px 40px;
+  }
+}

--- a/src/app/cast-crew-detail/cast-crew-detail.component.html
+++ b/src/app/cast-crew-detail/cast-crew-detail.component.html
@@ -1,53 +1,72 @@
-<div class="container">
-  <h1 class="title is-size-3">{{ date }}</h1>
-  <h1 class="title is-size-4">Cast and Crew</h1>
-  <div class="columns is-multiline">
-    <div class="column is-half" *ngFor="let person of allcastCrew">
-      <div class="box">
-        <article class="media">
-          <div class="media-left">
-            <figure class="image is-96x96">
-              <img [src]="person.Image" alt="{{ person.Title }}" />
-            </figure>
-          </div>
-          <div class="media-content">
-            <div class="content">
-              <p>
-                <a href="{{ person.Title_URL }}" target="_blank">{{
-                  person.Title
-                }}</a>
-                <br />
-                {{ person.Birthday }} |
-                <strong>{{ calculateAge(person.Birthday) }}</strong>
-                <br />
-                {{ findType(person) }}
-                <br />
-                <br />
-                <button (click)="downloadICSCalendar(person)" class="button">
-                  Download Calendar
-                </button>
-              </p>
-              <div class="bookmark-container">
-                <!--
-                <button
-                  class="transparent-button"
-                  (click)="toggleBookmark(movie)"
-                >
-                  <i
-                    class="fa-solid fa-bookmark"
-                    *ngIf="movie.isBookmarked"
-                  ></i>
-                  <i
-                    class="fa-regular fa-bookmark"
-                    *ngIf="!movie.isBookmarked"
-                  ></i>
-                </button>
-                  -->
-              </div>
-            </div>
-          </div>
-        </article>
-      </div>
+<div class="fe-bday">
+  <!-- Header -->
+  <header class="fe-bday__header">
+    <div class="fe-breadcrumb">
+      <a [routerLink]="['/castcrew']" class="fe-breadcrumb__back">
+        ← {{ monthName }} {{ headerYear }}
+      </a>
+      <span class="fe-breadcrumb__sep">·</span>
+      <span class="fe-breadcrumb__meta">{{ weekdayName }} · Week {{ weekNumber }}</span>
     </div>
+
+    <h1 class="fe-h1">
+      Birthdays <i class="fe-h1__accent">· {{ dayLabel }}</i>
+    </h1>
+
+    <p class="fe-bday__subtitle">
+      <ng-container *ngIf="!loading">
+        {{ allcastCrew.length }}
+        {{ allcastCrew.length === 1 ? 'person' : 'people' }} you follow
+        {{ allcastCrew.length === 1 ? 'is' : 'are' }} celebrating today
+      </ng-container>
+    </p>
+  </header>
+
+  <div *ngIf="loading" class="fe-loading-inline">Loading birthdays…</div>
+
+  <!-- Person cards -->
+  <div class="fe-bday__grid" *ngIf="!loading">
+    <article class="fe-person" *ngFor="let person of allcastCrew">
+      <div class="fe-person__avatar">
+        <img
+          *ngIf="person.Image"
+          [src]="person.Image"
+          alt="{{ person.Title }}"
+          loading="lazy"
+        />
+        <span *ngIf="!person.Image" class="fe-person__initials">{{
+          initials(person)
+        }}</span>
+      </div>
+
+      <div class="fe-person__body">
+        <div class="fe-person__top">
+          <h3 class="fe-person__name">{{ person.Title }}</h3>
+          <span class="fe-person__badge">Turns {{ turnsAge(person) }}</span>
+        </div>
+
+        <div class="fe-person__sub">
+          Born {{ person.Birthday }} · {{ role(person) }}
+        </div>
+
+        <div class="fe-person__actions">
+          <button class="fe-btn fe-btn--solid" (click)="downloadYearlyReminder(person)">
+            <i class="fas fa-download"></i> Yearly reminder
+          </button>
+          <a
+            class="fe-btn fe-btn--ghost"
+            [href]="person.Title_URL"
+            target="_blank"
+            rel="noopener"
+          >
+            Filmography
+          </a>
+        </div>
+      </div>
+    </article>
+
+    <p *ngIf="allcastCrew.length === 0" class="fe-empty">
+      No tracked birthdays on this day.
+    </p>
   </div>
 </div>

--- a/src/app/cast-crew-detail/cast-crew-detail.component.ts
+++ b/src/app/cast-crew-detail/cast-crew-detail.component.ts
@@ -5,6 +5,7 @@ import { BookmarkService } from '../service/bookmarked.service';
 import { DatabaseService } from '../service/database.service';
 import { SelectdateService } from '../service/selectdate.service';
 import { ICalendar } from 'datebook';
+import { MONTH_NAMES, WEEKDAY_NAMES, getIsoWeek } from '../date-utils';
 
 @Component({
   selector: 'app-cast-crew-detail',
@@ -18,7 +19,8 @@ export class CastCrewDetailComponent implements OnInit {
   composers: CastCrew[] = [];
   allcastCrew: CastCrew[] = [];
   date = '';
-  age = 0;
+  loading = true;
+
   constructor(
     private router: Router,
     private route: ActivatedRoute,
@@ -31,81 +33,114 @@ export class CastCrewDetailComponent implements OnInit {
     this.getCastCrew();
   }
 
-  calculateAge(birthday: string) {
-    const birthDate = new Date(birthday);
-    const currentDate = new Date();
-    let age = currentDate.getFullYear() - birthDate.getFullYear();
-    const monthDifference = currentDate.getMonth() - birthDate.getMonth();
-    if (
-      monthDifference < 0 ||
-      (monthDifference === 0 && currentDate.getDate() < birthDate.getDate())
-    ) {
-      age--;
-    }
-    return age;
+  // ----- Header view-model (computed from this.date, YYYY-MM-DD) -----
+
+  private dateObj(): Date {
+    const [y, m, d] = (this.date || '1970-01-01')
+      .split('-')
+      .map((p) => parseInt(p, 10));
+    return new Date(y, m - 1, d);
+  }
+
+  get monthName(): string {
+    return MONTH_NAMES[this.dateObj().getMonth()];
+  }
+
+  get dayNumber(): number {
+    return this.dateObj().getDate();
+  }
+
+  get headerYear(): number {
+    return this.dateObj().getFullYear();
+  }
+
+  get weekdayName(): string {
+    return WEEKDAY_NAMES[this.dateObj().getDay()];
+  }
+
+  get weekNumber(): number {
+    return getIsoWeek(this.dateObj());
+  }
+
+  get dayLabel(): string {
+    return `${this.monthName} ${this.dayNumber}`;
+  }
+
+  // ----- Person card helpers -----
+
+  initials(person: CastCrew): string {
+    const parts = (person.Title || '')
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean);
+    const letters = parts.slice(0, 2).map((p) => p[0]).join('');
+    return (letters || '?').toUpperCase();
+  }
+
+  // Age the person turns on this birthday.
+  turnsAge(person: CastCrew): number {
+    return new Date().getFullYear() - new Date(person.Birthday).getFullYear();
+  }
+
+  role(person: CastCrew): string {
+    if (this.actors.includes(person)) return 'Actor';
+    if (this.actresses.includes(person)) return 'Actress';
+    if (this.directors.includes(person)) return 'Director';
+    if (this.composers.includes(person)) return 'Composer';
+    return 'Cast & Crew';
   }
 
   async getCastCrew() {
+    this.loading = true;
     this.actors = await this.databaseService.getActors();
     this.actresses = await this.databaseService.getAcresses();
     this.directors = await this.databaseService.getDirectors();
     this.composers = await this.databaseService.getComposer();
-    //add to all to allcastCrew
-    this.allcastCrew = this.allcastCrew.concat(this.actors);
-    this.allcastCrew = this.allcastCrew.concat(this.actresses);
-    this.allcastCrew = this.allcastCrew.concat(this.directors);
-    this.allcastCrew = this.allcastCrew.concat(this.composers);
-    //remove duplicates from allcastCrew
-    this.allcastCrew = this.allcastCrew.filter(
+
+    let all: CastCrew[] = [
+      ...this.actors,
+      ...this.actresses,
+      ...this.directors,
+      ...this.composers,
+    ];
+    // de-duplicate by Title
+    all = all.filter(
       (thing, index, self) =>
         index === self.findIndex((t) => t.Title === thing.Title)
     );
-    //filter by date
+
     this.route.params.subscribe((params) => {
-      this.date = params['date']; // Access the 'date' parameter
+      this.date = params['date'];
       const selectedMonthDay = this.date.substring(5);
-      this.allcastCrew = this.allcastCrew.filter((castCrew) => {
-        const movieMonthDay = castCrew.Birthday.substring(5);
-        return movieMonthDay === selectedMonthDay;
-      });
+      this.allcastCrew = all.filter(
+        (person) => person.Birthday.substring(5) === selectedMonthDay
+      );
+      this.loading = false;
     });
   }
 
-  findType(castCrew: CastCrew) {
-    if (this.actors.includes(castCrew)) {
-      return 'Actor';
-    } else if (this.actresses.includes(castCrew)) {
-      return 'Actress';
-    } else if (this.directors.includes(castCrew)) {
-      return 'Director';
-    } else if (this.composers.includes(castCrew)) {
-      return 'Composer';
-    }
-    return 'Unknown';
-  }
-
-  downloadICSCalendar(castCrew: CastCrew) {
-    const eventDate = new Date(castCrew.Birthday);
-    const eventEnd = new Date(castCrew.Birthday);
+  // Download an .ics with a yearly-recurring birthday reminder.
+  downloadYearlyReminder(person: CastCrew) {
+    const eventDate = new Date(person.Birthday);
+    const eventEnd = new Date(person.Birthday);
     eventEnd.setDate(eventEnd.getDate() + 1);
 
     const config = {
-      title: castCrew.Title,
-      description: 'Birthday',
+      title: `${person.Title}'s birthday`,
+      description: `${this.role(person)} · born ${person.Birthday}`,
       start: eventDate,
       end: eventEnd,
       allDay: true,
+      recurrence: { frequency: 'YEARLY' },
     };
 
     const icsCalendar = new ICalendar(config);
     const icsData = icsCalendar.render();
-    const blob = new Blob([icsData], {
-      type: 'text/calendar;charset=utf-8',
-    });
+    const blob = new Blob([icsData], { type: 'text/calendar;charset=utf-8' });
 
     const downloadLink = document.createElement('a');
     downloadLink.href = window.URL.createObjectURL(blob);
-    downloadLink.setAttribute('download', `${castCrew.Title}.ics`);
+    downloadLink.setAttribute('download', `${person.Title}-birthday.ics`);
 
     document.body.appendChild(downloadLink);
     downloadLink.click();

--- a/src/app/cast-crew/cast-crew.component.css
+++ b/src/app/cast-crew/cast-crew.component.css
@@ -1,242 +1,274 @@
-.calendar {
+.fe-cal {
+  font-family: var(--font-ui);
+}
+
+/* Title row */
+.fe-cal__title {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding: 40px var(--page-x) 24px;
+}
+
+.fe-cal__title-left {
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  width: 100%;
 }
 
-.header {
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 10px;
-}
-
-.weekdays {
-  display: flex;
-}
-
-.weekday {
-  flex: 1;
-  text-align: center;
-  font-weight: bold;
-}
-
-.week {
-  display: flex;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.day {
-  flex: 1;
-  text-align: center;
-  padding: 10px;
-  border: 1px solid #ccc;
-  cursor: pointer;
-  /* Add the following lines to make each square the same width and height */
-  width: calc(100% / 7); /* Adjust as needed */
-  height: 180px; /* Adjust as needed */
-  position: relative;
-}
-
-.day2 {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 10px;
-  border: 1px solid #ccc;
-  text-align: center;
-  width: calc(100% / 7); /* Adjust as needed */
-  height: 100px; /* Adjust as needed */
-}
-
-.day:hover {
-  background-color: #3498db;
-}
-
-.small-text {
-  font-size: 12px; /* You can adjust the font size as needed */
-}
-
-.small-week-text {
-  font-size: 13px; /* You can adjust the font size as needed */
-}
-
-.date-selector {
-  justify-content: space-between;
-  align-items: center;
-  padding-bottom: 20px;
-}
-.select {
-  z-index: 1;
-  position: relative;
-}
-
-.month-title {
-  margin-left: auto; /* Push the month title to the right */
-}
-
-.film-background {
-  background-color: #049be5;
-  border: 2px solid #007bff;
-  color: #ffffff;
-  margin-bottom: 5px;
-  /*border-radius: 5px;*/
-}
-
-.day:hover {
-  background-color: #3498db;
-}
-
-.tooltip {
-  position: absolute;
-  bottom: 30px;
-  left: -20px;
-  background-color: #f9f9f9;
-  border: 1px solid #ccc;
-  padding: 10px;
-
-  z-index: 1;
-  width: 120%; /* to ensure the tooltip covers the full width of the day square */
-  display: none;
-  box-sizing: border-box;
-}
-
-.day.hovered .tooltip {
-  display: block;
-}
-
-.day.square {
-  position: relative;
-}
-
-.day-title {
-  margin-bottom: 10px;
-}
-
-.more-movies {
-  background-color: #7ec8f5; /* Lighter blue */
-  border: 2px solid #66b3ff;
-  color: #ffffff;
+.fe-eyebrow {
   font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--muted);
 }
 
-/* Additional or modified styles for horizontal week view */
+.fe-h1 {
+  font-family: var(--font-serif);
+  font-size: 60px;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+  margin: 6px 0 8px;
+  color: var(--text);
+}
 
-.week {
+.fe-h1 i {
+  font-style: italic;
+  color: var(--red);
+}
+
+.fe-subtitle {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.fe-cal__controls {
   display: flex;
-  justify-content: space-between;
-  align-items: stretch; /* Ensures all day squares are of equal height */
+  align-items: center;
+  gap: 8px;
 }
 
-.week-square {
-  height: 500px;
+.fe-iconbtn {
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
 }
 
-.week-day:hover {
-  background-color: #3498db;
+.fe-textbtn {
+  height: 34px;
+  padding: 0 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  cursor: pointer;
 }
 
-.week-view {
-  position: relative; /* Set the position context for absolute positioning */
+.fe-iconbtn:hover,
+.fe-textbtn:hover {
+  border-color: var(--border-strong);
 }
 
-.week-navigation {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 100%; /* Stretch the navigation to cover the entire height of the week view */
+.fe-vdivider {
+  width: 1px;
+  height: 24px;
+  background: var(--border);
+  margin: 0 4px;
 }
 
-.nav-button {
-  position: absolute;
-  top: 50%; /* Center the buttons vertically */
-  transform: translateY(
-    -50%
-  ); /* Adjust the position to truly center the buttons */
+.fe-segment {
+  display: flex;
+  background: var(--elev);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 3px;
+}
+
+.fe-segment__seg {
   border: none;
-  background-color: transparent;
-  font-size: 2em; /* Adjust the size of the arrows */
+  background: transparent;
+  color: var(--muted);
+  padding: 6px 14px;
+  border-radius: 6px;
+  font-family: var(--font-ui);
+  font-size: 13px;
   cursor: pointer;
 }
 
-.prev-button {
-  left: 0; /* Position the Previous button on the left */
-  margin-left: -50px;
+.fe-segment__seg.is-active {
+  background: var(--bg);
+  color: var(--text);
 }
 
-.next-button {
-  right: 0; /* Position the Next button on the right */
-  margin-right: -50px;
+/* Grid */
+.fe-grid-card {
+  margin: 0 var(--page-x) 40px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--card-radius);
+  overflow: hidden;
 }
 
-/* Optional: Add some padding and hover effect */
-.nav-button:hover {
-  background-color: rgba(0, 0, 0, 0.1);
+.fe-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
 }
 
-.day.today {
-  background-color: #a1a1a1;
+.fe-grid--head {
+  background: var(--elev);
+  border-bottom: 1px solid var(--border);
 }
 
-.bookmarked-movie {
-  background-color: #4cb965;
-  border: 2px solid #3f9b53;
-  color: #ffffff;
+.fe-dayhead {
+  padding: 12px 14px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  border-right: 1px solid var(--border);
+}
+
+.fe-dayhead:last-child {
+  border-right: none;
+}
+
+.fe-dayhead--wknd {
+  color: var(--red);
+}
+
+.fe-cell {
+  min-height: var(--cell-min-h);
+  padding: 12px;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.fe-cell:nth-child(7n) {
+  border-right: none;
+}
+
+.fe-cell:hover {
+  background: var(--elev);
+}
+
+.fe-cell.is-empty {
+  opacity: 0.45;
+  cursor: default;
+  background: var(--bg);
+}
+
+.fe-cell.is-today {
+  background: var(--red-soft);
+}
+
+.fe-cell__date {
+  font-family: var(--font-serif);
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--text);
+  margin-bottom: 6px;
+}
+
+.fe-cell.is-today .fe-cell__date {
+  color: var(--red);
+}
+
+.fe-pill {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 0;
+}
+
+.fe-pill__bar {
+  flex: none;
+  width: 3px;
+  height: 14px;
+  border-radius: 1px;
+  background: var(--red);
+}
+
+.fe-pill__title {
   font-size: 12px;
-  margin-bottom: 5px;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
+.fe-more {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--muted);
+  margin-top: 3px;
+}
+
+/* Week view */
+.fe-week {
+  position: relative;
+}
+
+.fe-week__nav {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.fe-cell--week {
+  min-height: 420px;
+}
+
+/* Loading spinner */
 .loading-animation {
   position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  inset: 0;
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: rgba(0, 0, 0, 0.5);
+  background: var(--bg);
 }
 
 .spinner {
-  border: 16px solid #f3f3f3;
-  border-top: 16px solid #3498db;
+  border: 6px solid var(--border);
+  border-top: 6px solid var(--red);
   border-radius: 50%;
-  width: 120px;
-  height: 120px;
-  animation: spin 2s linear infinite;
+  width: 64px;
+  height: 64px;
+  animation: spin 1s linear infinite;
 }
 
 @keyframes spin {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
+  to {
     transform: rotate(360deg);
   }
 }
 
-.weekend-day {
-  background-color: #f5f5f5;
-}
-
-.weekend-header {
-  background-color: #eaeaea;
-}
-
-/* Mobile adjustments */
 @media (max-width: 768px) {
-  .day {
-    height: 120px;
+  .fe-cal__title {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+    padding: 24px 20px 16px;
   }
-
-  .day2 {
-    height: 60px;
+  .fe-grid-card {
+    margin: 0;
+    padding-left: 20px;
+    padding-right: 20px;
   }
-
-  .week-square {
-    height: 300px;
+  .fe-cell {
+    min-height: 96px;
   }
 }

--- a/src/app/cast-crew/cast-crew.component.html
+++ b/src/app/cast-crew/cast-crew.component.html
@@ -1,134 +1,86 @@
 <div *ngIf="loading" class="loading-animation">
   <div class="spinner"></div>
 </div>
-<div *ngIf="!loading">
-  <div class="container">
-    <div class="calendar">
-    <div class="date-selector">
-      <div class="field is-grouped">
-        <div class="control">
-          <div class="select">
-            <select [(ngModel)]="selectedMonth" (change)="onDateChange()">
-              <option *ngFor="let month of months; let i = index" [value]="i">
-                {{ month }}
-              </option>
-            </select>
-          </div>
-        </div>
-        <div class="control" *ngIf="!isMobile">
-          <div class="select">
-            <select [(ngModel)]="selectedView">
-              <option>Month</option>
-              <option>Week</option>
-            </select>
-            <!--
-              <select [(ngModel)]="selectedYear" (change)="onDateChange()">
-                <option *ngFor="let year of years" [value]="year">
-                  {{ year }}
-                </option>
-              </select>
-              -->
-          </div>
-        </div>
-        <div class="month-title title">
-          <h1>Birthdays for {{ months[selectedMonth] }} {{ selectedYear }}</h1>
-        </div>
-      </div>
+
+<div *ngIf="!loading" class="fe-cal">
+  <!-- Title row -->
+  <header class="fe-cal__title">
+    <div class="fe-cal__title-left">
+      <div class="fe-eyebrow">BIRTHDAY CALENDAR</div>
+      <h1 class="fe-h1">
+        {{ months[selectedMonth] }} <i>{{ selectedYear }}</i>
+      </h1>
+      <p class="fe-subtitle">{{ birthdaysThisMonth }} birthdays this month</p>
     </div>
 
-    <div class="week">
-      <div class="day2 header">Mon</div>
-      <div class="day2 header">Tue</div>
-      <div class="day2 header">Wed</div>
-      <div class="day2 header">Thu</div>
-      <div class="day2 header">Fri</div>
-      <div class="day2 header weekend-header">Sat</div>
-      <div class="day2 header weekend-header">Sun</div>
-    </div>
-    <div *ngIf="selectedView === 'Month'" class="month-view">
-      <div class="week" *ngFor="let week of weeks">
-        <ng-container *ngFor="let day of week; let i = index">
-          <div
-            class="day square"
-            [ngClass]="{ 'weekend-day': i === 5 || i === 6 }"
-            (click)="onDayClick(day)"
-            (mouseenter)="onDayMouseEnter(day)"
-            (mouseleave)="onDayMouseLeave()"
-            [class.hovered]="isHovered(day)"
-            [class.today]="isToday(day)"
-          >
-            <ng-container *ngIf="day !== 0">
-              <div class="day-title">{{ day }}</div>
-
-              <div *ngFor="let person of getMoviesForDay(day); let i = index">
-                <div
-                  class="small-text"
-                  [ngClass]="{
-                    'bookmarked-movie': person.isBookmarked,
-                    'film-background': !person.isBookmarked
-                  }"
-                >
-                  <strong style="color: white">{{
-                    person.Title | slice : 0 : 25
-                  }}</strong>
-                  <!-- ({{ movie.release_date | date : "yyyy" }}) -->
-                </div>
-              </div>
-              <div *ngIf="getMovieCountForDay(day) >= 1" class="movie-count">
-                <div class="more-movies">
-                  {{ getMovieCountForDay(day) }} more
-                </div>
-                <!-- Tooltip div -->
-                <div class="tooltip" *ngIf="isHovered(day)" [@fadeInOut]>
-                  <div
-                    *ngFor="let person of getFullMoviesForDay(day)"
-                    class="small-text film-background"
-                  >
-                    {{ person.Title }}
-                  </div>
-                </div>
-              </div>
-            </ng-container>
-          </div>
-        </ng-container>
+    <div class="fe-cal__controls">
+      <button class="fe-iconbtn" (click)="previousMonth()" aria-label="Previous month">‹</button>
+      <button class="fe-textbtn" (click)="goToToday()">Today</button>
+      <button class="fe-iconbtn" (click)="nextMonth()" aria-label="Next month">›</button>
+      <div class="fe-vdivider"></div>
+      <div class="fe-segment">
+        <button class="fe-segment__seg" [class.is-active]="selectedView === 'Month'" (click)="selectedView = 'Month'">Month</button>
+        <button class="fe-segment__seg" [class.is-active]="selectedView === 'Week'" (click)="selectedView = 'Week'">Week</button>
+        <button class="fe-segment__seg" (click)="goToDayView()">Day</button>
       </div>
     </div>
-    <div *ngIf="selectedView === 'Week'" class="week">
-      <div class="week-navigation">
-        <button class="nav-button prev-button" (click)="previousWeek()">
-          <i class="fas fa-arrow-left"></i>
-          <!-- Left arrow icon (using FontAwesome) -->
-        </button>
-        <button class="nav-button next-button" (click)="nextWeek()">
-          <i class="fas fa-arrow-right"></i>
-          <!-- Right arrow icon (using FontAwesome) -->
-        </button>
-      </div>
-      <div
-        *ngFor="let day of weeks[0]; let i = index"
-        class="day square week-square"
-        [ngClass]="{ 'weekend-day': i === 5 || i === 6 }"
-        (click)="onDayClick(day)"
-      >
-        <ng-container *ngIf="day !== 0">
-          <div class="day-title">{{ day }}</div>
+  </header>
 
-          <div *ngFor="let person of getMoviesForWeek(day); let i = index">
-            <div
-              class="small-text"
-              [ngClass]="{
-                'bookmarked-movie': person.isBookmarked,
-                'film-background': !person.isBookmarked
-              }"
-            >
-              <strong style="color: white">
-                {{ person.Title | slice : 0 : 25 }}
-              </strong>
+  <!-- Calendar grid -->
+  <div class="fe-grid-card">
+    <div class="fe-grid fe-grid--head">
+      <div class="fe-dayhead">MONDAY</div>
+      <div class="fe-dayhead">TUESDAY</div>
+      <div class="fe-dayhead">WEDNESDAY</div>
+      <div class="fe-dayhead">THURSDAY</div>
+      <div class="fe-dayhead">FRIDAY</div>
+      <div class="fe-dayhead fe-dayhead--wknd">SATURDAY</div>
+      <div class="fe-dayhead fe-dayhead--wknd">SUNDAY</div>
+    </div>
+
+    <div *ngIf="selectedView === 'Month'">
+      <div class="fe-grid" *ngFor="let week of weeks">
+        <div
+          class="fe-cell"
+          *ngFor="let day of week"
+          [class.is-empty]="day === 0"
+          [class.is-today]="isToday(day)"
+          (click)="onDayClick(day)"
+        >
+          <ng-container *ngIf="day !== 0">
+            <div class="fe-cell__date">{{ day }}</div>
+            <div class="fe-pill" *ngFor="let person of getPeopleForDay(day)">
+              <span class="fe-pill__bar"></span>
+              <span class="fe-pill__title">{{ person.Title }}</span>
             </div>
-          </div>
-        </ng-container>
+            <div class="fe-more" *ngIf="getPersonCountForDay(day) >= 1">
+              +{{ getPersonCountForDay(day) }} more
+            </div>
+          </ng-container>
+        </div>
+      </div>
+    </div>
+
+    <div *ngIf="selectedView === 'Week'" class="fe-week">
+      <div class="fe-week__nav">
+        <button class="fe-iconbtn" (click)="previousWeek()" aria-label="Previous week">‹</button>
+        <button class="fe-iconbtn" (click)="nextWeek()" aria-label="Next week">›</button>
+      </div>
+      <div class="fe-grid">
+        <div
+          class="fe-cell fe-cell--week"
+          *ngFor="let day of weeks[0]"
+          (click)="onDayClick(day)"
+        >
+          <ng-container *ngIf="day !== 0">
+            <div class="fe-cell__date">{{ day }}</div>
+            <div class="fe-pill" *ngFor="let person of getPeopleForWeek(day)">
+              <span class="fe-pill__bar"></span>
+              <span class="fe-pill__title">{{ person.Title }}</span>
+            </div>
+          </ng-container>
+        </div>
       </div>
     </div>
   </div>
 </div>
-<br />

--- a/src/app/cast-crew/cast-crew.component.ts
+++ b/src/app/cast-crew/cast-crew.component.ts
@@ -1,41 +1,17 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { CalendarEvent, CalendarMonthViewDay } from 'angular-calendar';
-import * as moment from 'moment';
-import { BookmarkService } from '../service/bookmarked.service';
-import { IFilm } from '../filmresult';
 import { SelectdateService } from '../service/selectdate.service';
-import { ImdbService } from '../service/imdb.service';
-import {
-  trigger,
-  state,
-  style,
-  transition,
-  animate,
-} from '@angular/animations';
 import { DatabaseService } from '../service/database.service';
 import { CastCrew } from '../cast-crew';
+import { MONTH_NAMES } from '../date-utils';
 
 @Component({
   selector: 'app-cast-crew',
   templateUrl: './cast-crew.component.html',
   styleUrls: ['./cast-crew.component.css'],
-  animations: [
-    trigger('fadeInOut', [
-      state(
-        'void',
-        style({
-          opacity: 0,
-        })
-      ),
-      transition('void <=> *', animate(400)),
-    ]),
-  ],
 })
 export class CastCrewComponent implements OnInit {
   private _selectedView = 'Month';
-
-  isMobile = false;
 
   loading = true;
 
@@ -48,30 +24,10 @@ export class CastCrewComponent implements OnInit {
   composers: CastCrew[] = [];
   allcastCrew: CastCrew[] = [];
   weeks: number[][] = [];
-  actorList: String[] = [];
-  months: string[] = [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December',
-  ];
-  years: number[] = Array.from(
-    { length: 62 }, // Change the length to cover a larger range of years
-    (_, i) => new Date().getFullYear() - 60 + i
-  );
-  hoveredDay: number | null = null;
-  hoverTimeout: any = null;
+  months: string[] = MONTH_NAMES;
+
   constructor(
     private router: Router,
-    private service: BookmarkService,
     private dateService: SelectdateService,
     private databaseService: DatabaseService
   ) {
@@ -81,15 +37,6 @@ export class CastCrewComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.isMobile = window.innerWidth <= 768;
-    if (this.isMobile) {
-      this.selectedView = 'Week';
-    } else {
-      this.generateMonthCalendar();
-    }
-  }
-
-  onDateChange(): void {
     this.generateMonthCalendar();
   }
 
@@ -99,76 +46,55 @@ export class CastCrewComponent implements OnInit {
     this.actresses = await this.databaseService.getAcresses();
     this.directors = await this.databaseService.getDirectors();
     this.composers = await this.databaseService.getComposer();
-    //add to all to allcastCrew
-    this.allcastCrew = this.allcastCrew.concat(this.actors);
-    this.allcastCrew = this.allcastCrew.concat(this.actresses);
-    this.allcastCrew = this.allcastCrew.concat(this.directors);
-    this.allcastCrew = this.allcastCrew.concat(this.composers);
-    //remove duplicates from allcastCrew
-    this.allcastCrew = this.allcastCrew.filter(
-      (thing, index, self) => index === self.findIndex((t) => t.Title === thing.Title)
+
+    this.allcastCrew = [
+      ...this.actors,
+      ...this.actresses,
+      ...this.directors,
+      ...this.composers,
+    ].filter(
+      (thing, index, self) =>
+        index === self.findIndex((t) => t.Title === thing.Title)
     );
 
     this.loading = false;
   }
 
   generateMonthCalendar(): void {
-    // Clear the weeks array
     this.loading = true;
     this.weeks = [];
     this.getCastCrew();
 
-    // Create a new date for the selected month and year
     const currentDate = new Date(this.selectedYear, this.selectedMonth, 1);
-
-    // Find the first day of the week for the selected month
-    // Adjust so the week starts on Monday instead of Sunday
-    const firstDayOfWeek = (currentDate.getDay() + 6) % 7; // 0 (Monday) to 6 (Sunday)
-
-    // Get the number of days in the selected month
+    const firstDayOfWeek = (currentDate.getDay() + 6) % 7; // Mon=0 .. Sun=6
     const lastDayOfMonth = new Date(
       this.selectedYear,
       this.selectedMonth + 1,
       0
     ).getDate();
 
-    // Calculate the number of days to add before the first day of the month
-    const daysBefore = firstDayOfWeek;
-
-    // Calculate the total number of days to display (5 weeks x 7 days)
-    const totalDays = 5 * 7;
-
-    // Initialize variables for tracking the current day and week
     let currentDay = 1;
     let currentWeek: number[] = [];
 
-    // Fill in empty days before the first day of the month
-    for (let i = 0; i < daysBefore; i++) {
-      currentWeek.push(0); // Use null to represent empty days
+    for (let i = 0; i < firstDayOfWeek; i++) {
+      currentWeek.push(0);
     }
 
-    // Populate the days of the month
     while (currentDay <= lastDayOfMonth) {
       currentWeek.push(currentDay);
-
-      // If we've reached the end of the week, start a new week
       if (currentWeek.length === 7) {
         this.weeks.push(currentWeek);
         currentWeek = [];
       }
-
       currentDay++;
     }
 
-    // Add the remaining empty days to complete 5 weeks
     while (currentWeek.length < 7) {
-      currentWeek.push(0); // Use null to represent empty days
+      currentWeek.push(0);
     }
     if (currentWeek.length > 0) {
-      this.weeks.push(currentWeek); // Ensure that the last week gets added to the weeks array
+      this.weeks.push(currentWeek);
     }
-
-    // Add the weeks to ensure you have a total of 5 weeks
     while (this.weeks.length < 5) {
       this.weeks.push(currentWeek);
       currentWeek = [];
@@ -176,55 +102,77 @@ export class CastCrewComponent implements OnInit {
   }
 
   generateWeekCalendar(): void {
-    // Clear the weeks array
     this.loading = true;
     this.weeks = [];
     this.getCastCrew();
 
-    // Assume that selectedDate is the date around which you want to build your week view.
     const startDate = new Date(this.selectedDate);
-    // Adjust so the week starts on Monday
-    const dayOfWeek = (this.selectedDate.getDay() + 6) % 7; // 0 (Monday) to 6 (Sunday)
+    const dayOfWeek = (this.selectedDate.getDay() + 6) % 7;
     startDate.setDate(this.selectedDate.getDate() - dayOfWeek);
 
     const endDate = new Date(startDate);
     endDate.setDate(startDate.getDate() + 6);
 
     const currentWeek: number[] = [];
-
     for (let d = startDate; d <= endDate; d.setDate(d.getDate() + 1)) {
       currentWeek.push(d.getDate());
     }
-
     this.weeks.push(currentWeek);
   }
 
+  // ----- Counts -----
+
+  get birthdaysThisMonth(): number {
+    const mm = String(this.selectedMonth + 1).padStart(2, '0');
+    return this.allcastCrew.filter(
+      (p) => p.Birthday && p.Birthday.substring(5, 7) === mm
+    ).length;
+  }
+
+  // ----- Navigation -----
+
+  previousMonth(): void {
+    if (this.selectedMonth === 0) {
+      this.selectedMonth = 11;
+      this.selectedYear--;
+    } else {
+      this.selectedMonth--;
+    }
+    this.generateMonthCalendar();
+  }
+
+  nextMonth(): void {
+    if (this.selectedMonth === 11) {
+      this.selectedMonth = 0;
+      this.selectedYear++;
+    } else {
+      this.selectedMonth++;
+    }
+    this.generateMonthCalendar();
+  }
+
+  goToToday(): void {
+    const now = new Date();
+    this.selectedMonth = now.getMonth();
+    this.selectedYear = now.getFullYear();
+    this.generateMonthCalendar();
+  }
+
+  goToDayView(): void {
+    this.dateService.selectedDate = this.selectedDate;
+    this.router.navigate(['/castcrew/', this.formatDateToISO(this.selectedDate)]);
+  }
+
   onDayClick(day: number): void {
+    if (day === 0) return;
     this.selectedDate.setFullYear(this.selectedYear, this.selectedMonth, day);
     this.dateService.selectedDate = this.selectedDate;
-    const formattedDate = this.formatDateToISO(this.selectedDate);
-    // Navigate to the selected date's detail page
-    this.router.navigate(['/castcrew/', formattedDate]);
-  }
-
-  isHovered(day: number): boolean {
-    return this.hoveredDay === day;
-  }
-
-  onDayMouseEnter(day: number): void {
-    this.hoverTimeout = setTimeout(() => {
-      this.hoveredDay = day;
-    }, 400); // 2000 milliseconds (2 seconds) delay
-  }
-
-  onDayMouseLeave(): void {
-    clearTimeout(this.hoverTimeout); // clear the timeout
-    this.hoveredDay = null;
+    this.router.navigate(['/castcrew/', this.formatDateToISO(this.selectedDate)]);
   }
 
   formatDateToISO(inputDate: Date): string {
     const year = inputDate.getFullYear();
-    const month = String(inputDate.getMonth() + 1).padStart(2, '0'); // Month is 0-based
+    const month = String(inputDate.getMonth() + 1).padStart(2, '0');
     const day = String(inputDate.getDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
   }
@@ -236,35 +184,26 @@ export class CastCrewComponent implements OnInit {
     return `${formattedMonth}-${formattedDay}`;
   }
 
-  getMoviesForDay(day: number): any[] {
+  getPeopleForDay(day: number): CastCrew[] {
     const dayStr = this.formatDate(day);
-    const moviesForDay = this.allcastCrew.filter(
-      (person) => person.Birthday.slice(5) === dayStr
-    );
-    return moviesForDay.slice(0, 3);
+    return this.allcastCrew
+      .filter((person) => person.Birthday.slice(5) === dayStr)
+      .slice(0, 3);
   }
 
-  getMoviesForWeek(day: number): any[] {
-    const dayStr = this.formatDate(day);
-    const moviesForDay = this.allcastCrew.filter(
-      (person) => person.Birthday.slice(5) === dayStr
-    );
-    return moviesForDay;
-  }
-
-  getMovieCountForDay(day: number): number {
-    const dayStr = this.formatDate(day);
-    const moviesForDay = this.allcastCrew.filter(
-      (person) => person.Birthday.slice(5) === dayStr
-    );
-    return moviesForDay.length - this.getMoviesForDay(day).length;
-  }
-
-  getFullMoviesForDay(day: number): any[] {
+  getPeopleForWeek(day: number): CastCrew[] {
     const dayStr = this.formatDate(day);
     return this.allcastCrew.filter(
       (person) => person.Birthday.slice(5) === dayStr
     );
+  }
+
+  getPersonCountForDay(day: number): number {
+    const dayStr = this.formatDate(day);
+    const total = this.allcastCrew.filter(
+      (person) => person.Birthday.slice(5) === dayStr
+    ).length;
+    return total - Math.min(total, 3);
   }
 
   public get selectedView() {
@@ -288,7 +227,6 @@ export class CastCrewComponent implements OnInit {
   nextWeek(): void {
     this.selectedDate.setDate(this.selectedDate.getDate() + 7);
     this.selectedMonth = this.selectedDate.getMonth();
-
     this.generateWeekCalendar();
   }
 

--- a/src/app/date-utils.spec.ts
+++ b/src/app/date-utils.spec.ts
@@ -1,0 +1,18 @@
+import { getIsoWeek, MONTH_NAMES, WEEKDAY_NAMES } from './date-utils';
+
+describe('date-utils', () => {
+  it('getIsoWeek returns week 1 for a Jan-1 Thursday (2026-01-01)', () => {
+    expect(getIsoWeek(new Date(2026, 0, 1))).toBe(1);
+  });
+
+  it('getIsoWeek returns week 23 for 2026-06-04 (matches the design)', () => {
+    expect(getIsoWeek(new Date(2026, 5, 4))).toBe(23);
+  });
+
+  it('has 12 month names and 7 weekday names', () => {
+    expect(MONTH_NAMES.length).toBe(12);
+    expect(WEEKDAY_NAMES.length).toBe(7);
+    expect(MONTH_NAMES[5]).toBe('June');
+    expect(WEEKDAY_NAMES[4]).toBe('Thursday');
+  });
+});

--- a/src/app/date-utils.ts
+++ b/src/app/date-utils.ts
@@ -1,0 +1,24 @@
+export const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+export const WEEKDAY_NAMES = [
+  'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday',
+];
+
+/** ISO-8601 week number (weeks start Monday; week 1 contains the first Thursday). */
+export function getIsoWeek(date: Date): number {
+  const d = new Date(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
+  );
+  const dayNum = (d.getUTCDay() + 6) % 7; // Mon=0 .. Sun=6
+  d.setUTCDate(d.getUTCDate() - dayNum + 3); // nearest Thursday
+  const firstThursday = new Date(Date.UTC(d.getUTCFullYear(), 0, 4));
+  const firstDayNum = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstDayNum + 3);
+  return (
+    1 +
+    Math.round((d.getTime() - firstThursday.getTime()) / (7 * 24 * 3600 * 1000))
+  );
+}


### PR DESCRIPTION
Birthdays detail (castcrew/:date): two-column person-card grid with avatar (image or gradient initials), "Turns N" badge, born/role line, yearly-recurring reminder .ics, and Filmography link; new breadcrumb + "Birthdays · Month Day" header.

Cast & Crew calendar index (castcrew): restyled to the shared calendar visual language (title row, prev/next month, Today, Month/Week/Day segment, token grid with birthday-name pills + "+N more"); removed the dead hover/animation code and fixed the mobile data-load bug.

Adds src/app/date-utils.ts (getIsoWeek + month/weekday names, shared) + spec.