### PR TITLE
Redesign Awards page to Modern Minimal

### DIFF
--- a/src/app/awards/awards.component.css
+++ b/src/app/awards/awards.component.css
@@ -1,0 +1,209 @@
+.fe-awards {
+  font-family: var(--font-ui);
+  color: var(--text);
+}
+
+/* Header */
+.fe-awards__header {
+  padding: 40px var(--page-x) 0;
+}
+
+.fe-eyebrow {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.fe-h1 {
+  font-family: var(--font-serif);
+  font-size: 56px;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+  margin: 6px 0 0;
+  color: var(--text);
+}
+
+.fe-awards__subtitle {
+  font-size: 14px;
+  color: var(--text-muted);
+  margin: 10px 0 0;
+}
+
+.fe-loading-inline,
+.fe-empty {
+  color: var(--muted);
+  font-size: 13px;
+  padding: 8px var(--page-x);
+}
+
+/* Sections */
+.fe-section {
+  padding: 28px var(--page-x) 0;
+}
+
+.fe-section:last-of-type {
+  padding-bottom: 48px;
+}
+
+.fe-section__title {
+  font-family: var(--font-serif);
+  font-size: 26px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 0 0 16px;
+}
+
+.fe-awards__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+/* Card */
+.fe-award {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--card-radius);
+  background: var(--surface);
+}
+
+.fe-award__logo {
+  flex: none;
+  width: 64px;
+  height: 64px;
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #efe7d7, #d6cdbb);
+}
+
+:root[data-theme='dark'] .fe-award__logo {
+  background: linear-gradient(135deg, var(--elev), var(--border-strong));
+}
+
+.fe-award__logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.fe-award__initials {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 20px;
+  color: var(--text-muted);
+}
+
+.fe-award__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.fe-award__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.fe-award__name {
+  font-family: var(--font-serif);
+  font-size: 20px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  margin: 0;
+  color: var(--text);
+}
+
+.fe-award__badge {
+  flex: none;
+  padding: 3px 8px;
+  border-radius: var(--chip-radius);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.fe-award__badge.is-upcoming {
+  background: var(--red-soft);
+  border-color: var(--red);
+  color: var(--red-ink);
+}
+
+.fe-award__meta {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 6px;
+}
+
+.fe-award__rel {
+  color: var(--muted);
+}
+
+.fe-award__actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.fe-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border-radius: 6px;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  border: 1px solid transparent;
+}
+
+.fe-btn--solid {
+  background: var(--text);
+  color: var(--surface);
+}
+
+.fe-btn--solid:hover {
+  opacity: 0.9;
+}
+
+.fe-btn--ghost {
+  background: var(--surface);
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.fe-btn--ghost:hover {
+  border-color: var(--border-strong);
+}
+
+/* Responsive */
+@media (max-width: 900px) {
+  .fe-awards__header {
+    padding: 24px 20px 0;
+  }
+  .fe-h1 {
+    font-size: 40px;
+  }
+  .fe-section {
+    padding: 20px 20px 0;
+  }
+  .fe-awards__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/awards/awards.component.html
+++ b/src/app/awards/awards.component.html
@@ -1,37 +1,94 @@
-<div class="container">
-  <div
-    class="header-container"
-    style="display: flex; align-items: center; justify-content: space-between"
-  >
-    <h1 class="title">Awards</h1>
-  </div>
-  <div class="columns is-multiline">
-    <div class="column is-half" *ngFor="let award of awards">
-      <div class="box" style="padding-bottom: 20px">
-        <article class="media">
-          <div class="media-left">
-            <figure class="image is-96x96">
-              <img
-                [src]="award.url || 'path/to/default/image.png'"
-                alt="logo"
-              />
-            </figure>
-          </div>
-          <div class="media-content">
-            <div class="content">
-              <p>
-                <strong>
-                  <a href="{{ award.imdb }}" target="_blank">{{
-                    award.name
-                  }}</a>
-                </strong>
-                <br />
-                Date: {{ award.date }}
-              </p>
-            </div>
-          </div>
+<div class="fe-awards">
+  <!-- Header -->
+  <header class="fe-awards__header">
+    <div class="fe-eyebrow">AWARDS SEASON</div>
+    <h1 class="fe-h1">Awards</h1>
+    <p class="fe-awards__subtitle" *ngIf="!loading">
+      {{ upcomingAwards.length }} upcoming · {{ awards.length }} ceremonies tracked
+    </p>
+  </header>
+
+  <div *ngIf="loading" class="fe-loading-inline">Loading awards…</div>
+
+  <ng-container *ngIf="!loading">
+    <!-- Upcoming -->
+    <section class="fe-section" *ngIf="upcomingAwards.length">
+      <h2 class="fe-section__title">Upcoming</h2>
+      <div class="fe-awards__grid">
+        <article class="fe-award" *ngFor="let award of upcomingAwards">
+          <ng-container
+            *ngTemplateOutlet="card; context: { $implicit: award, upcoming: true }"
+          ></ng-container>
         </article>
       </div>
+    </section>
+
+    <!-- Past -->
+    <section class="fe-section" *ngIf="pastAwards.length">
+      <h2 class="fe-section__title">Past</h2>
+      <div class="fe-awards__grid">
+        <article class="fe-award" *ngFor="let award of pastAwards">
+          <ng-container
+            *ngTemplateOutlet="card; context: { $implicit: award, upcoming: false }"
+          ></ng-container>
+        </article>
+      </div>
+    </section>
+
+    <p
+      *ngIf="!upcomingAwards.length && !pastAwards.length"
+      class="fe-empty"
+    >
+      No awards ceremonies to show yet.
+    </p>
+  </ng-container>
+</div>
+
+<!-- Reusable card body -->
+<ng-template #card let-award let-upcoming="upcoming">
+  <div class="fe-award__logo">
+    <img
+      *ngIf="award.url"
+      [src]="award.url"
+      alt="{{ award.name }}"
+      loading="lazy"
+    />
+    <span *ngIf="!award.url" class="fe-award__initials">{{
+      initials(award)
+    }}</span>
+  </div>
+
+  <div class="fe-award__body">
+    <div class="fe-award__top">
+      <h3 class="fe-award__name">{{ award.name }}</h3>
+      <span
+        class="fe-award__badge"
+        [class.is-upcoming]="upcoming"
+      >{{ upcoming ? 'Upcoming' : 'Past' }}</span>
+    </div>
+
+    <div class="fe-award__meta">
+      {{ displayDate(award) }}
+      <span class="fe-award__rel" *ngIf="relative(award)"> · {{ relative(award) }}</span>
+    </div>
+
+    <div class="fe-award__actions">
+      <button
+        class="fe-btn fe-btn--solid"
+        *ngIf="parse(award)"
+        (click)="downloadICSCalendar(award)"
+      >
+        <i class="fas fa-download"></i> Add to calendar
+      </button>
+      <a
+        class="fe-btn fe-btn--ghost"
+        *ngIf="award.imdb"
+        [href]="award.imdb"
+        target="_blank"
+        rel="noopener"
+      >
+        Details
+      </a>
     </div>
   </div>
-</div>
+</ng-template>

--- a/src/app/awards/awards.component.ts
+++ b/src/app/awards/awards.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { Award } from '../awards';
 import { DatabaseService } from '../service/database.service';
+import { ICalendar } from 'datebook';
+
 @Component({
   selector: 'app-awards',
   templateUrl: './awards.component.html',
@@ -8,6 +10,10 @@ import { DatabaseService } from '../service/database.service';
 })
 export class AwardsComponent implements OnInit {
   awards: Award[] = [];
+  upcomingAwards: Award[] = [];
+  pastAwards: Award[] = [];
+  loading = true;
+
   constructor(private databaseService: DatabaseService) {}
 
   ngOnInit(): void {
@@ -15,6 +21,107 @@ export class AwardsComponent implements OnInit {
   }
 
   async getAwards() {
-    this.awards = await this.databaseService.getAwards();
+    this.loading = true;
+    this.awards = (await this.databaseService.getAwards()) || [];
+
+    const startOfToday = new Date();
+    startOfToday.setHours(0, 0, 0, 0);
+
+    const dated = this.awards.filter((a) => this.parse(a) !== null);
+
+    this.upcomingAwards = dated
+      .filter((a) => (this.parse(a) as Date) >= startOfToday)
+      .sort((a, b) => this.time(a) - this.time(b)); // soonest first
+
+    this.pastAwards = dated
+      .filter((a) => (this.parse(a) as Date) < startOfToday)
+      .sort((a, b) => this.time(b) - this.time(a)); // most recent first
+
+    this.loading = false;
+  }
+
+  // ----- Date helpers -----
+
+  /** Parse an award date string into a Date, or null if unparseable. */
+  parse(award: Award): Date | null {
+    if (!award?.date) return null;
+    const d = new Date(award.date);
+    return isNaN(d.getTime()) ? null : d;
+  }
+
+  private time(award: Award): number {
+    const d = this.parse(award);
+    return d ? d.getTime() : 0;
+  }
+
+  displayDate(award: Award): string {
+    const d = this.parse(award);
+    if (!d) return award.date || 'Date TBA';
+    return d.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  /** Human relative label, e.g. "in 84 days", "today", "3 months ago". */
+  relative(award: Award): string {
+    const d = this.parse(award);
+    if (!d) return '';
+    const start = new Date();
+    start.setHours(0, 0, 0, 0);
+    const target = new Date(d);
+    target.setHours(0, 0, 0, 0);
+
+    const dayMs = 24 * 60 * 60 * 1000;
+    const diffDays = Math.round((target.getTime() - start.getTime()) / dayMs);
+
+    if (diffDays === 0) return 'today';
+    const ahead = diffDays > 0;
+    const days = Math.abs(diffDays);
+    let value: string;
+    if (days < 31) {
+      value = `${days} day${days === 1 ? '' : 's'}`;
+    } else if (days < 365) {
+      const months = Math.round(days / 30);
+      value = `${months} month${months === 1 ? '' : 's'}`;
+    } else {
+      const years = Math.round(days / 365);
+      value = `${years} year${years === 1 ? '' : 's'}`;
+    }
+    return ahead ? `in ${value}` : `${value} ago`;
+  }
+
+  initials(award: Award): string {
+    const parts = (award.name || '').trim().split(/\s+/).filter(Boolean);
+    const letters = parts.slice(0, 2).map((p) => p[0]).join('');
+    return (letters || '?').toUpperCase();
+  }
+
+  downloadICSCalendar(award: Award) {
+    const eventDate = this.parse(award);
+    if (!eventDate) return;
+    const eventEnd = new Date(eventDate);
+    eventEnd.setDate(eventEnd.getDate() + 1);
+
+    const config = {
+      title: award.name,
+      description: 'Awards ceremony',
+      start: eventDate,
+      end: eventEnd,
+      allDay: true,
+    };
+
+    const icsCalendar = new ICalendar(config);
+    const icsData = icsCalendar.render();
+    const blob = new Blob([icsData], { type: 'text/calendar;charset=utf-8' });
+
+    const downloadLink = document.createElement('a');
+    downloadLink.href = window.URL.createObjectURL(blob);
+    downloadLink.setAttribute('download', `${award.name}.ics`);
+
+    document.body.appendChild(downloadLink);
+    downloadLink.click();
+    document.body.removeChild(downloadLink);
   }
 }


### PR DESCRIPTION
Replaces the Bulma list with a token-based layout: eyebrow + Newsreader header with counts, and award cards split into Upcoming / Past sections (sorted by date). Each card shows the ceremony logo (or gradient-initials fallback), name, formatted date with a relative label ("in 84 days" / "3 months ago"), an Upcoming/Past status badge, an "Add to calendar" .ics download (datebook), and a "Details" link to IMDb.